### PR TITLE
Skip location if details could not be retrieved

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,3 +62,4 @@ Contributors
 
 * `@briancline <https://github.com/briancline>`_
 * `@rthill <https://github.com/rthill>`_
+* `@jtai <https://github.com/jtai>`_

--- a/rxv/ssdp.py
+++ b/rxv/ssdp.py
@@ -62,7 +62,10 @@ def discover(timeout=1.5):
 def rxv_details(location):
     """Looks under given UPNP url, and checks if Yamaha amplituner lives there
        returns RxvDetails if yes, None otherwise"""
-    xml = ET.XML(requests.get(location).content)
+    try:
+        xml = ET.XML(requests.get(location).content)
+    except:
+        return None
     url_base_el = xml.find(URL_BASE_QUERY)
     if url_base_el is None:
         return None


### PR DESCRIPTION
I have a device on my network that responds to the initial discover but closes the connection when we try to grab the rxv details. 

@wuub 