### PR TITLE
Ignore case for SSDP discovery

### DIFF
--- a/rxv/ssdp.py
+++ b/rxv/ssdp.py
@@ -48,7 +48,7 @@ def discover(timeout=1.5):
 
     results = []
     for res in responses:
-        m = re.search(r"LOCATION:(.+)", res.decode('utf-8'))
+        m = re.search(r"LOCATION:(.+)", res.decode('utf-8'), re.IGNORECASE)
         if not m:
             continue
         url = m.group(1).strip()


### PR DESCRIPTION
This fix a bug where my RX-V679 isn't detected because it's ssdp response is "Location:" and not "LOCATION:"