### PR TITLE
Set timeout on created socket object instead of changing the global default

### DIFF
--- a/rxv/ssdp.py
+++ b/rxv/ssdp.py
@@ -34,10 +34,10 @@ RxvDetails = namedtuple("RxvDetails", "ctrl_url model_name friendly_name")
 def discover(timeout=1.5):
     """Crude SSDP discovery. Returns a list of RxvDetails objects
        with data about Yamaha Receivers in local network"""
-    socket.setdefaulttimeout(timeout)
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
     sock.sendto(SSDP_MSEARCH_QUERY.encode("utf-8"), (SSDP_ADDR, SSDP_PORT))
+    sock.settimeout(timeout)
 
     responses = []
     try:


### PR DESCRIPTION
When home-assistant added a yamaha component, people started reporting random discovery and frontend UI failures caused by truncated files. Disabling that component made things again work as expected. I believe this is caused by this call to `socket.setdefaulttimeout` which sets a global timeout of 1.5 seconds on _any_  socket created after rxv discovery has run.

(patch is untested as I have no yamaha receiver to test against)