### PR TITLE
rxv enhancements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Contributors
 * `@jtai <https://github.com/jtai>`_
 * `@ahocquet <https://github.com/ahocquet>`_
 * `@Raynes <https:/github.com/Raynes>`_
+* `@sdague <https://github.com/sdague>`_
 
 Users
 =====

--- a/rxv/__init__.py
+++ b/rxv/__init__.py
@@ -9,9 +9,13 @@ __all__ = ['RXV']
 
 
 def find(timeout=1.5):
-    """Find all Yamah receivers on local network using SSDP search"""
+    """Find all Yamah receivers on local network using SSDP search."""
     return [
-        RXV(ctrl_url=ri.ctrl_url, model_name=ri.model_name, friendly_name=ri.friendly_name) 
+        RXV(
+            ctrl_url=ri.ctrl_url,
+            model_name=ri.model_name,
+            friendly_name=ri.friendly_name,
+            unit_desc_url=ri.unit_desc_url
+        )
         for ri in ssdp.discover(timeout=timeout)
     ]
-

--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -53,7 +53,7 @@ class RXV(object):
             warnings.warn("Using IP address as a Control URL is deprecated")
             ctrl_url = 'http://%s/YamahaRemoteControl/ctrl' % ctrl_url
         self.ctrl_url = ctrl_url
-        self.unit_desc_url = unit_desc_url
+        self.unit_desc_url = unit_desc_url or re.sub('ctrl$', 'desc.xml', ctrl_url)
         self.model_name = model_name
         self.friendly_name = friendly_name
         self._inputs_cache = None

--- a/rxv/ssdp.py
+++ b/rxv/ssdp.py
@@ -25,10 +25,11 @@ SSDP_MSEARCH_QUERY = \
 
 URL_BASE_QUERY = '*/{urn:schemas-yamaha-com:device-1-0}X_URLBase'
 CONTROL_URL_QUERY = '***/{urn:schemas-yamaha-com:device-1-0}X_controlURL'
+UNITDESC_URL_QUERY = '***/{urn:schemas-yamaha-com:device-1-0}X_unitDescURL'
 MODEL_NAME_QUERY = "{urn:schemas-upnp-org:device-1-0}device/{urn:schemas-upnp-org:device-1-0}modelName"
 FRIENDLY_NAME_QUERY = "{urn:schemas-upnp-org:device-1-0}device/{urn:schemas-upnp-org:device-1-0}friendlyName"
 
-RxvDetails = namedtuple("RxvDetails", "ctrl_url model_name friendly_name")
+RxvDetails = namedtuple("RxvDetails", "ctrl_url unit_desc_url, model_name friendly_name")
 
 
 def discover(timeout=1.5):
@@ -69,12 +70,14 @@ def rxv_details(location):
     url_base_el = xml.find(URL_BASE_QUERY)
     if url_base_el is None:
         return None
-    ctrl_url = xml.find(CONTROL_URL_QUERY).text
+    ctrl_url_local = xml.find(CONTROL_URL_QUERY).text
+    ctrl_url = urljoin(url_base_el.text, ctrl_url_local)
+    unit_desc_url_local = xml.find(UNITDESC_URL_QUERY).text
+    unit_desc_url = urljoin(url_base_el.text, unit_desc_url_local)
     model_name = xml.find(MODEL_NAME_QUERY).text
     friendly_name = xml.find(FRIENDLY_NAME_QUERY).text
-    ctrl_url = urljoin(url_base_el.text, ctrl_url)
 
-    return RxvDetails(ctrl_url, model_name, friendly_name)
+    return RxvDetails(ctrl_url, unit_desc_url, model_name, friendly_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This creates a new find_all_zones method that creates an RXV for all
zones that could exist in the receiver. This is discovered by probing
the desc.xml.

This provides the ability to poke at the zones independently as if
they were dedicated stereos, which they mostly act like (there is some
coupling, if both are on the same input, like NET_RADIO, they will end
up playing the same stream). However power and volume are independent
for the 2.

Starting point for discussion on how to do this right.

In reference to issue #21 