### PR TITLE
Add support for basic music controls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,13 @@ In most cases **rxv** module will manage to obtain locations of local compatible
   >>> rx.input = "HDMI1"
   >>> rx.input
   "HDMI1"
+  >>> rx.is_playback_supported()
+  False
+  >>> rx.input = "AirPlay"
+  >>> rx.is_playback_supported()
+  True
+  >>> rx.play()
+  >>> rx.next()
 
 
 If SSDP causes you some problems, `ctrl_url` can be provided by hand.::
@@ -66,6 +73,7 @@ Contributors
 * `@ahocquet <https://github.com/ahocquet>`_
 * `@Raynes <https:/github.com/Raynes>`_
 * `@sdague <https://github.com/sdague>`_
+* `@postlund <https://github.com/postlund>`_
 
 Users
 =====

--- a/rxv/exceptions.py
+++ b/rxv/exceptions.py
@@ -17,3 +17,9 @@ ReponseException = ResponseException
 class MenuUnavailable(RXVException):
     """Menu control unavailable for current input"""
     pass
+
+
+class PlaybackUnavailable(RXVException):
+    """Raised when playback function called on unsupported source."""
+    def __init__(self, source, action):
+        super().__init__('{} does not support {}'.format(source, action))


### PR DESCRIPTION
It is now possible to use basic music controls like play(), pause(), stop(),
next() and previous() for the currently active source.

NB: Will only do something useful if the active source supports it.