### PR TITLE
Add more specific playback support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,9 @@ In most cases **rxv** module will manage to obtain locations of local compatible
   >>> rx.input = "AirPlay"
   >>> rx.is_playback_supported()
   True
+  >>> from rxv import PlaybackSupport
+  >>> (rx.get_playback_support() & PlaybackSupport.PLAY) != 0
+  True
   >>> rx.play()
   >>> rx.next()
 

--- a/rxv/__init__.py
+++ b/rxv/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import division, absolute_import, print_function
 
 from .rxv import RXV
+from .rxv import PlaybackSupport
 from . import ssdp
 
 __all__ = ['RXV']

--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -19,10 +19,30 @@ try:
 except ImportError:
     from urlparse import urlparse
 
-# Add sources that support playback, i.e. play, pause, etc.
-SOURCES_SUPPORTING_PLAYBACK = [
-    'SERVER', 'USB', 'NET RADIO', 'NAPSTER',
-    'TUNER', 'iPod (USB)', 'AirPlay']
+# Used as an enum to indicate support for individual playback controls
+class PlaybackSupport:
+    NONE  = 0
+
+    PLAY  = (1 << 0)
+    STOP  = (1 << 1)
+    PAUSE = (1 << 2)
+    NEXT  = (1 << 3)
+    PREV  = (1 << 4)
+
+    BASIC = (PLAY | STOP | PAUSE)
+    NAVIGATION = (NEXT | PREV)
+    ALL   = (BASIC | NAVIGATION)
+
+# Add sources that support playback and what they support
+SOURCES_SUPPORTING_PLAYBACK = {
+    'SERVER': PlaybackSupport.ALL,
+    'USB': PlaybackSupport.ALL,
+    'NET RADIO': PlaybackSupport.BASIC,
+    'NAPSTER': PlaybackSupport.ALL,
+    'TUNER': PlaybackSupport.ALL,
+    'iPod (USB)': PlaybackSupport.ALL,
+    'AirPlay': PlaybackSupport.ALL
+}
 
 BasicStatus = namedtuple("BasicStatus", "on volume mute input")
 PlayStatus = namedtuple("PlayStatus", "playing artist album song station")
@@ -131,6 +151,13 @@ class RXV(object):
 
     def off(self):
         return self.on(False)
+
+    def get_playback_support(self, input_source=None):
+        if input_source is None:
+            input_source = self.input
+        if input_source not in SOURCES_SUPPORTING_PLAYBACK:
+            return PlaybackSupport.NONE
+        return SOURCES_SUPPORTING_PLAYBACK[input_source]
 
     def is_playback_supported(self, input_source=None):
         if input_source is None:


### PR DESCRIPTION
The method get_playback_support() returns a bit field for a specific source.
So, sources can individually report support for different controls.

This change intentionally breaks the previous API as this is a much better
API and we don't want to build technical debt already.