### PR TITLE
Introduce logging for failed requests.

### DIFF
--- a/rxv/__init__.py
+++ b/rxv/__init__.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function
+import logging
 
 from .rxv import RXV
 from .rxv import PlaybackSupport
 from . import ssdp
 
 __all__ = ['RXV']
+
+# disable default logging of warnings to stderr. If a consuming
+# application sets up logging, it will work as expected.
+logging.getLogger('rxv').addHandler(logging.NullHandler())
 
 
 def find(timeout=1.5):

--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -272,6 +272,14 @@ class RXV(object):
         if not src_name:
             return None
 
+        # if the source does not support play_status, don't try,
+        # otherwise you can get really odd behavior.
+        #
+        # TODO: instead of a hard coded list, this should be queriable
+        # from desc.xml.
+        if src_name not in SOURCES_SUPPORTING_PLAYBACK:
+            return None
+
         request_text = PlayGet.format(src_name=src_name)
         res = self._request('GET', request_text, zone_cmd=False)
 


### PR DESCRIPTION
In response to Home Assistant bug -
https://github.com/home-assistant/home-assistant/issues/4226

When things go wrong with a request in unexpected ways, we really
don't have enough information to figure out what just happened. This
is especially true with hardware generations that none of the upstream
developers have.

This adds logging support to the library, and introduces a couple of
error cases where we will log low level details of a failure to help
debug these kinds of issues in the future.