### PR TITLE
Enhanced error handling

### DIFF
--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -98,6 +98,9 @@ class RXV(object):
         """Pull and parse the desc.xml so we can query it later."""
         try:
             desc_xml = self._session.get(self.unit_desc_url).content
+            if not desc_xml:
+                logger.error("Unsupported Yamaha device? Failed to fetch %s" % self.unit_desc_url)
+                return
             self._desc_xml = ET.fromstring(desc_xml)
         except ET.ParseError:
             logger.exception("Invalid XML returned for request %s: %s",


### PR DESCRIPTION
If you try to use the library with an unsupported Yamaha device, (YamahaRemoteControl/desc.xml is not available) python will throw a message like:
`[rxv] Invalid XML returned for request http://192.168.123.123:80/YamahaRemoteControl/desc.xml: b''`.
With this fix it will provide you a hint about a most likely not supported device instead of XML data not valid.
Another way to prevent the XML error would be to check if the status_code of the request is in the range 200-299.