### PR TITLE
Round to nearest 0.5 db when setting volume

### DIFF
--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -521,7 +521,17 @@ class RXV(object):
 
     @volume.setter
     def volume(self, value):
-        value = str(int(value * 10))
+        """Convert volume for setting.
+
+        We're passing around volume in standard db units, like -52.0
+        db. The API takes int values. However, the API also only takes
+        int values that corespond to half db steps (so -52.0 and -51.5
+        are valid, -51.8 is not).
+
+        Through the power of math doing the int of * 2, then * 5 will
+        ensure we only get half steps.
+        """
+        value = str(int(value * 2) * 5)
         exp = 1
         unit = 'dB'
 


### PR DESCRIPTION
The rxv library interface passes around well understood db volumes
over it's interface, values such as -53.5db and the like. The Yamaha
API operates in terms of deci-db as an integer - i.e. 535.

However, most (if not all) Yamaha receivers have a 5 deci db
resolution, and trying to set values such as 531 cause an error. This
change makes the rxv library round all set calls up to the nearest
half db to remove these errors. These are especially triggered when
coming from Home Assistant which has it's own 0 - 100 idea of volume,
so is very often not hitting a defined db boundary.

Closes Bug #35