### PR TITLE
Scenes can't be set over their name - instead the number has to be used

### DIFF
--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -331,8 +331,9 @@ class RXV(object):
 
     @scene.setter
     def scene(self, scene_name):
-        assert scene_name in self.scenes()
-        request_text = Input.format(parameter=scene_name)
+        assert scene_name in self._scenes_cache
+        scene_number = self._scenes_cache.get(scene_name)
+        request_text = Scene.format(parameter=scene_number)
         self._request('PUT', request_text)
 
     def scenes(self):
@@ -342,10 +343,9 @@ class RXV(object):
             if scenes is None:
                 return False
 
-            supports = scenes.findall('.//*')
-            self._scenes_cache = list()
-            for s in supports:
-                self._scenes_cache.append(s.text)
+            self._scenes_cache = {}
+            for scene in scenes:
+                self._scenes_cache[scene.text] = scene.tag.replace("_", " ")
         return self._scenes_cache
 
     @property


### PR DESCRIPTION
I found a bug with the scene selection today. The select scene command expects the scene number, instead of the scene name (Scene 2 instead of TV Viewing).