### PR TITLE
Fix license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=open('README.rst').read(),
     author='Wojciech Bederski',
     url="https://github.com/wuub/rxv",
-    license='MIT',
+    license='BSD',
     author_email='github@wuub.net',
     packages=find_packages(),
     install_requires=['requests', 'defusedxml'],


### PR DESCRIPTION
Setup.py specified MIT as license although the project is licensed under BSD.
Or is this intentional?