### PR TITLE
Apply REUSE specifications to make sure all files have a license.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: Unlicense
+
 *.py[cod]
 .cache
 # C extensions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: Unlicense
+
 language: python
 matrix:
   fast_finish: true

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,26 @@
+Copyright (c) <year> <owner>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/Unlicense.txt
+++ b/LICENSES/Unlicense.txt
@@ -1,0 +1,20 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+this software, either in source code form or as a compiled binary, for any
+purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and
+to the detriment of our heirs and successors. We intend this dedication to
+be an overt act of relinquishment in perpetuity of all present and future
+rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. For more information,
+please refer to <https://unlicense.org/>

--- a/MANIFEST.in.license
+++ b/MANIFEST.in.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: Unlicense

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 test: 
 	flake8
 	isort --recursive --check-only --diff

--- a/PROTOCOL.rst.license
+++ b/PROTOCOL.rst.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/README.rst.license
+++ b/README.rst.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: Unlicense
+
 .

--- a/rxv/__init__.py
+++ b/rxv/__init__.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 

--- a/rxv/exceptions.py
+++ b/rxv/exceptions.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 

--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 

--- a/rxv/ssdp.py
+++ b/rxv/ssdp.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 [wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 # encoding: utf-8
 from __future__ import absolute_import, division, print_function
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: Unlicense
+
 mock
 pytest>=2.9.2
 pytest-cov>=2.3.1

--- a/tests/check_integration.py
+++ b/tests/check_integration.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 import time
 
 import rxv

--- a/tests/samples/rx-a2060-desc.xml.license
+++ b/tests/samples/rx-a2060-desc.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v1030-netradio-response.xml.license
+++ b/tests/samples/rx-v1030-netradio-response.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v1030-spotify-response.xml.license
+++ b/tests/samples/rx-v1030-spotify-response.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v1030-tuner-response.xml.license
+++ b/tests/samples/rx-v1030-tuner-response.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v579-desc.xml.license
+++ b/tests/samples/rx-v579-desc.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v675-desc.xml.license
+++ b/tests/samples/rx-v675-desc.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v675-inputs-resp.xml.license
+++ b/tests/samples/rx-v675-inputs-resp.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v775-desc.xml.license
+++ b/tests/samples/rx-v775-desc.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/rx-v775-inputs-resp.xml.license
+++ b/tests/samples/rx-v775-inputs-resp.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/samples/tsr-5810-desc.xml.license
+++ b/tests/samples/tsr-5810-desc.xml.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/tests/test_feature_support.py
+++ b/tests/test_feature_support.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from io import open
 
 import requests_mock

--- a/tests/test_rxv.py
+++ b/tests/test_rxv.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
 from io import open
 
 import requests_mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,7 @@
+; SPDX-FileCopyrightText: 2013 Joanna Tustanowska & Wojciech Bederski
+;
+; SPDX-License-Identifier: Unlicense
+
 [tox]
 envlist = py27,py34,py35,py36,py37,pypy
 skip_missing_interpreters = True


### PR DESCRIPTION
REUSE (https://reuse.software/) is a specification to make it easier and
safer to specify the licenses of files within a repository. It allows
specifying license and copyright information via SPDX tags, or attached
`.license` files.

For all the files in this repository:

 - Apply the copyright information as present in the LICENSE file.
 - For all non-configuration files, apply BSD-3-Clause license that match
   the LICENSE file.
 - For configuration (and empty) files that wouldn't be copyrightable, use
   Unlicense (https://unlicense.org/).
 - For test XML files, to avoid changing the files themselves, use a
  `.license` file attached to each.