### PR TITLE
Add integration test for RX-V577

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@
   include Makefile
   recursive-include tests *.py
   recursive-include tests *.xml
+  recursive-include tests *.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,8 +44,9 @@ testing =
     flake8
     mock
     pytest
-    pytest-cov 
+    pytest-cov
     pytest-timeout
+    pytest-vcr
     requests-mock
     tox
 
@@ -77,7 +78,7 @@ commands = py.test --cov --cov-report=term --cov-report=xml {posargs}
 
 [testenv:flake8]
 description = run flake8 under {basepython}
-commands = flake8 rxv/ tests/ 
+commands = flake8 rxv/ tests/
 extras = testing
 
 [testenv:manifest]

--- a/tests/integration/cassettes/test_RX_V577/RX-V577.yaml
+++ b/tests/integration/cassettes/test_RX_V577/RX-V577.yaml
@@ -1,0 +1,795 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: http://192.168.1.100/YamahaRemoteControl/desc.xml
+  response:
+    body:
+      string: <?xml version="1.0" encoding="utf-8"?><Unit_Description Version="1.2"
+        Unit_Name="RX-V577"><Language Code="en">Title_1</Language><Menu Func="Unit"
+        Title_1="System" YNC_Tag="System"><Menu Func="Event" Title_1="Event"><Put_1
+        Func="Event_On" ID="P1">On</Put_1><Put_1 Func="Event_Off" ID="P1">Off</Put_1><Get><Cmd
+        ID="G1">Param_1</Cmd><Param_1><Direct Func="Event_On">On</Direct><Direct Func="Event_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func="Network_Update" Title_1="Network Update"><Menu Func="Update_Status"
+        Title_1="Status"><Get><Cmd ID="G4">Param_1</Cmd><Param_1><Direct Func="Update_Status_Ready">Available</Direct><Direct
+        Func="Update_Status_Not_Ready">Unavailable</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Rename" Title_1="Name" List_Type="Text_Input"><Put_2><Cmd ID="P3">Param_1</Cmd><Param_1><Text>1,15,UTF-8</Text></Param_1></Put_2><Get><Cmd
+        ID="G2">Param_1</Cmd><Param_1><Text>1,15,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Power_Control" Title_1="Power Control"><Menu Func="Power" Title_1="Power"><Put_1
+        Func="Power_On" ID="P2">On</Put_1><Put_1 Func="Power_Standby" ID="P2">Standby</Put_1></Menu><Menu
+        Func="Net_Standby" Title_1="Network Standby"><Put_1 Func="Net_Standby_On"
+        ID="P4">On</Put_1><Put_1 Func="Net_Standby_Off" ID="P4">Off</Put_1><Get><Cmd
+        ID="G3">Param_1</Cmd><Param_1><Direct Func="Net_Standby_On">On</Direct><Direct
+        Func="Net_Standby_Off">Off</Direct></Param_1></Get></Menu></Menu><Menu Func_Ex="DMR"
+        Title_1="DMC Control"><Put_1 Func_Ex="DMR_Off" ID="P5">Disable</Put_1><Put_1
+        Func_Ex="DMR_On" ID="P5">Enable</Put_1><Get><Cmd ID="G5">Param_1</Cmd><Param_1><Direct
+        Func_Ex="DMR_Off">Disable</Direct><Direct Func_Ex="DMR_On">Enable</Direct></Param_1></Get></Menu><Cmd_List><Define
+        ID="P1">System,Misc,Event,Notice</Define><Define ID="P2">System,Power_Control,Power</Define><Define
+        ID="P3">System,Misc,Network,Network_Name</Define><Define ID="P4">System,Misc,Network,Network_Standby</Define><Define
+        ID="P5">System,Misc,Network,DMC_Control</Define><Define ID="G1">System,Misc,Event,Notice</Define><Define
+        ID="G2">System,Misc,Network,Network_Name</Define><Define ID="G3">System,Misc,Network,Network_Standby</Define><Define
+        ID="G4">System,Misc,Update,Yamaha_Network_Site,Status</Define><Define ID="G5">System,Misc,Network,DMC_Control</Define></Cmd_List></Menu><Menu
+        Func="Subunit" Title_1="Main Zone" YNC_Tag="Main_Zone"><Menu Func="Rename"
+        Title_1="Name" List_Type="Text_Input"><Put_2><Cmd ID="P5">Param_1</Cmd><Param_1><Text>1,9,Latin-1</Text></Param_1></Put_2><Get><Cmd
+        ID="G3">Name,Zone=Param_1</Cmd><Param_1><Text>1,9,Latin-1</Text></Param_1></Get></Menu><Menu
+        Title_1="Input/Scene" List_Type="Icon"><Menu Func="Input" Func_Ex="Input"
+        Title_1="Input" List_Type="Icon" Icon_on="/YamahaRemoteControl/Icons/icon000.png"><Put_2><Cmd
+        ID="P4">Param_1</Cmd><Param_1><Indirect ID="G2"/></Param_1></Put_2><Get><Cmd
+        ID="G1">Input,Input_Sel=Param_1</Cmd><Param_1><Indirect ID="G2"/></Param_1></Get></Menu><Menu
+        Func="Input" Func_Ex="Scene" Title_1="Scene" List_Type="Icon" Icon_on="/YamahaRemoteControl/Icons/icon001.png"><Put_2><Cmd
+        ID="P6">Param_1</Cmd><Param_1><Indirect ID="G4"/></Param_1></Put_2><Get><Cmd
+        ID="G1">Input,Input_Sel=Param_1</Cmd><Param_1><Indirect ID="G2"/></Param_1></Get></Menu></Menu><Menu
+        Func="Vol" Title_1="Volume"><Menu Func="Vol_Lvl" List_Type="Slider" Title_1="Level"><Put_2><Cmd
+        Type="Number" ID="P2">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>-805,165,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number" ID="G1">Volume,Lvl,Val=Param_1:Volume,Lvl,Exp=Param_2:Volume,Lvl,Unit=Param_3</Cmd><Param_1><Range>-805,165,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Get></Menu><Menu
+        Func="Vol_Mute" Title_1="Mute"><Put_1 Func="Vol_Mute_On" ID="P3">On</Put_1><Put_1
+        Func="Vol_Mute_Off" ID="P3">Off</Put_1><Get><Cmd ID="G1">Volume,Mute=Param_1</Cmd><Param_1><Direct
+        Func="Vol_Mute_On">On</Direct><Direct Func="Vol_Mute_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func="Vol_dB" Title_1="Scale (dB)"><Put_1 Func="Vol_dB_On" ID="P30">dB</Put_1><Put_1
+        Func="Vol_dB_Off" ID="P30">0-97</Put_1><Get><Cmd ID="G1">Volume,Scale=Param_1</Cmd><Param_1><Direct
+        Func="Vol_dB_On">dB</Direct><Direct Func="Vol_dB_Off">0-97</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Power_Control" Title_1="Power Control"><Menu Func="Power" Title_1="Power"><Put_1
+        Func="Power_On" ID="P1">On</Put_1><Put_1 Func="Power_Standby" ID="P1">Standby</Put_1><Get><Cmd
+        ID="G1">Power_Control,Power=Param_1</Cmd><Param_1><Direct Func="Power_On">On</Direct><Direct
+        Func="Power_Standby">Standby</Direct></Param_1></Get></Menu><Menu Func="Sleep"
+        Title_1="Sleep"><Put_1 Func="Sleep_Last" ID="P23">Last</Put_1><Put_1 Func="Sleep_1"
+        ID="P23">120 min</Put_1><Put_1 Func="Sleep_2" ID="P23">90 min</Put_1><Put_1
+        Func="Sleep_3" ID="P23">60 min</Put_1><Put_1 Func="Sleep_4" ID="P23">30 min</Put_1><Put_1
+        Func="Sleep_Off" ID="P23">Off</Put_1><Get><Cmd ID="G1">Power_Control,Sleep=Param_1</Cmd><Param_1><Direct
+        Func="Sleep_1">120 min</Direct><Direct Func="Sleep_2">90 min</Direct><Direct
+        Func="Sleep_3">60 min</Direct><Direct Func="Sleep_4">30 min</Direct><Direct
+        Func="Sleep_Off">Off</Direct></Param_1></Get></Menu></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1 ID="P24"
+        Layout="24" Func="Play">Play</Put_1><Put_1 ID="P24" Layout="23" Func="Pause">Pause</Put_1><Put_1
+        ID="P24" Layout="22" Func="Stop">Stop</Put_1></Menu><Menu Func="Plus_Minus"
+        Title_1="Skip"><Put_1 ID="P24" Layout="28" Func="Plus_1">Skip Fwd</Put_1><Put_1
+        ID="P24" Layout="27" Func="Minus_1">Skip Rev</Put_1></Menu></Menu><Menu Func="List_Control"
+        Title_1="List Control"><Menu Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1
+        ID="P18" Layout="5" Func="Cursor_Up">Up</Put_1><Put_1 ID="P18" Layout="9"
+        Func="Cursor_Down">Down</Put_1><Put_1 ID="P18" Layout="6" Func="Cursor_Left">Left</Put_1><Put_1
+        ID="P18" Layout="8" Func="Cursor_Right">Right</Put_1><Put_1 ID="P18" Layout="10"
+        Func="Cursor_Return">Return</Put_1><Put_1 ID="P18" Layout="7" Func="Cursor_Sel">Sel</Put_1><Put_1
+        ID="P18" Func="Cursor_Home">Return to Home</Put_1><Put_1 ID="P19" Layout="3"
+        Func="Cursor_Setup" Title_1="Setup">On Screen</Put_1><Put_1 ID="P19" Layout="4"
+        Func="Cursor_Option">Option</Put_1><Put_1 ID="P19" Layout="11" Func="Cursor_Display">Display</Put_1></Menu><Menu
+        Title_1="Contents Display" Func="Contents_Disp"><Put_1 Func="Contents_Disp_On"
+        ID="P32">On</Put_1><Put_1 Func="Contents_Disp_Off" ID="P32">Off</Put_1><Get><Cmd
+        ID="G9">Param_1</Cmd><Param_1><Direct Func="Contents_Disp_On">On</Direct><Direct
+        Func="Contents_Disp_Off">Off</Direct></Param_1></Get></Menu></Menu><Menu Title_1="Setup"><Menu
+        Func_Ex="Surround" Title_1="Surround"><Menu Func_Ex="Program" Title_1="Program"
+        List_Type="Icon"><Put_2><Cmd ID="P9">Param_1</Cmd><Param_1><Direct Icon_on="/YamahaRemoteControl/Icons/icon018.png">Hall
+        in Munich</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon019.png">Hall
+        in Vienna</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon014.png">Chamber</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon013.png">Cellar Club</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon020.png">The Roxy Theatre</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon021.png">The Bottom Line</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon037.png">Sports</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon027.png">Action
+        Game</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon032.png">Roleplaying
+        Game</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon030.png">Music
+        Video</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon033.png">Standard</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon036.png">Spectacle</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon029.png">Sci-Fi</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon028.png">Adventure</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon034.png">Drama</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon035.png">Mono
+        Movie</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon039.png">Surround
+        Decoder</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon024.png">2ch
+        Stereo</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon025.png">7ch
+        Stereo</Direct></Param_1></Put_2><Get><Cmd ID="G1">Surround,Program_Sel,Current,Sound_Program=Param_1</Cmd><Param_1><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon018.png">Hall in Munich</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon019.png">Hall in Vienna</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon014.png">Chamber</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon013.png">Cellar
+        Club</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon020.png">The
+        Roxy Theatre</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon021.png">The
+        Bottom Line</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon037.png">Sports</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon027.png">Action Game</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon032.png">Roleplaying Game</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon030.png">Music Video</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon033.png">Standard</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon036.png">Spectacle</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon029.png">Sci-Fi</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon028.png">Adventure</Direct><Direct
+        Icon_on="/YamahaRemoteControl/Icons/icon034.png">Drama</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon035.png">Mono
+        Movie</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon039.png">Surround
+        Decoder</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon024.png">2ch
+        Stereo</Direct><Direct Icon_on="/YamahaRemoteControl/Icons/icon025.png">7ch
+        Stereo</Direct></Param_1></Get></Menu><Menu Func_Ex="Straight" Title_1="Straight"><Put_1
+        Func_Ex="Straight_On" ID="P10">On</Put_1><Put_1 Func_Ex="Straight_Off" ID="P10">Off</Put_1><Get><Cmd
+        ID="G1">Surround,Program_Sel,Current,Straight=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Straight_On">On</Direct><Direct Func_Ex="Straight_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Enhancer" Title_1="Enhancer"><Put_1 Func_Ex="Enhancer_On" ID="P11">On</Put_1><Put_1
+        Func_Ex="Enhancer_Off" ID="P11">Off</Put_1><Get><Cmd ID="G1">Surround,Program_Sel,Current,Enhancer=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Enhancer_On">On</Direct><Direct Func_Ex="Enhancer_Off">Off</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Tone" Title_1="Tone"><Menu Func="Bass" List_Type="Slider" Title_1="Bass"><Put_2><Cmd
+        Type="Number" ID="P7">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number" ID="G1">Sound_Video,Tone,Bass,Val=Param_1:Sound_Video,Tone,Bass,Exp=Param_2:Sound_Video,Tone,Bass,Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Get></Menu><Menu
+        Func="Treble" List_Type="Slider" Title_1="Treble"><Put_2><Cmd Type="Number"
+        ID="P8">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number" ID="G1">Sound_Video,Tone,Treble,Val=Param_1:Sound_Video,Tone,Treble,Exp=Param_2:Sound_Video,Tone,Treble,Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Get></Menu></Menu><Menu
+        Func_Ex="SW_Trim" List_Type="Slider" Title_1="Subwoofer Trim"><Put_2><Cmd
+        Type="Number" ID="P22">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number" ID="G1">Volume,Subwoofer_Trim,Val=Param_1:Volume,Subwoofer_Trim,Exp=Param_2:Volume,Subwoofer_Trim,Unit=Param_3</Cmd><Param_1><Range>-60,60,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Get></Menu><Menu
+        Func_Ex="Adaptive_DRC" Title_1="Adaptive DRC"><Put_1 Func_Ex="Adaptive_DRC_Auto"
+        ID="P12">Auto</Put_1><Put_1 Func_Ex="Adaptive_DRC_Off" ID="P12">Off</Put_1><Get><Cmd
+        ID="G1">Sound_Video,Adaptive_DRC=Param_1</Cmd><Param_1><Direct Func_Ex="Adaptive_DRC_Auto">Auto</Direct><Direct
+        Func_Ex="Adaptive_DRC_Off">Off</Direct></Param_1></Get></Menu><Menu Func_Ex="CINEMA_DSP_3D"
+        Title_1="CINEMA DSP 3D"><Put_1 Func_Ex="CINEMA_DSP_3D_Auto" ID="P13">Auto</Put_1><Put_1
+        Func_Ex="CINEMA_DSP_3D_Off" ID="P13">Off</Put_1><Get><Cmd ID="G1">Surround,_3D_Cinema_DSP=Param_1</Cmd><Param_1><Direct
+        Func_Ex="CINEMA_DSP_3D_Auto">Auto</Direct><Direct Func_Ex="CINEMA_DSP_3D_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Direct" Title_1="Direct"><Put_1 Func_Ex="Direct_On" ID="P17">On</Put_1><Put_1
+        Func_Ex="Direct_Off" ID="P17">Off</Put_1><Get><Cmd ID="G1">Sound_Video,Direct,Mode=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Direct_On">On</Direct><Direct Func_Ex="Direct_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Extra_Bass" Title_1="Extra Bass"><Put_1 Func_Ex="Extra_Bass_On" ID="P29">Auto</Put_1><Put_1
+        Func_Ex="Extra_Bass_Off" ID="P29">Off</Put_1><Get><Cmd ID="G1">Sound_Video,Extra_Bass=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Extra_Bass_On">Auto</Direct><Direct Func_Ex="Extra_Bass_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="HDMI_Standby_Through" Title_1="HDMI Standby Through"><Get><Cmd ID="G1">Sound_Video,HDMI,Standby_Through_Info=Param_1</Cmd><Param_1><Direct
+        Func_Ex="HDMI_Standby_Through_On">On</Direct><Direct Func_Ex="HDMI_Standby_Through_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Speaker_AB" Title_1="Speaker A/B"><Menu Func_Ex="Speaker_A" Title_1="Speaker
+        A"><Put_1 Func_Ex="Speaker_A_On" ID="P27">On</Put_1><Put_1 Func_Ex="Speaker_A_Off"
+        ID="P27">Off</Put_1><Get><Cmd ID="G1">Speaker_Preout,Speaker_AB,Speaker_A=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Speaker_A_On">On</Direct><Direct Func_Ex="Speaker_A_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Speaker_B" Title_1="Speaker B"><Put_1 Func_Ex="Speaker_B_On" ID="P28">On</Put_1><Put_1
+        Func_Ex="Speaker_B_Off" ID="P28">Off</Put_1><Get><Cmd ID="G1">Speaker_Preout,Speaker_AB,Speaker_B=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Speaker_B_On">On</Direct><Direct Func_Ex="Speaker_B_Off">Off</Direct></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">Main_Zone,Power_Control,Power</Define><Define ID="P2">Main_Zone,Volume,Lvl</Define><Define
+        ID="P3">Main_Zone,Volume,Mute</Define><Define ID="P4">Main_Zone,Input,Input_Sel</Define><Define
+        ID="P5">Main_Zone,Config,Name,Zone</Define><Define ID="P6">Main_Zone,Scene,Scene_Sel</Define><Define
+        ID="P7">Main_Zone,Sound_Video,Tone,Bass</Define><Define ID="P8">Main_Zone,Sound_Video,Tone,Treble</Define><Define
+        ID="P9">Main_Zone,Surround,Program_Sel,Current,Sound_Program</Define><Define
+        ID="P10">Main_Zone,Surround,Program_Sel,Current,Straight</Define><Define ID="P11">Main_Zone,Surround,Program_Sel,Current,Enhancer</Define><Define
+        ID="P12">Main_Zone,Sound_Video,Adaptive_DRC</Define><Define ID="P13">Main_Zone,Surround,_3D_Cinema_DSP</Define><Define
+        ID="P14">Main_Zone,Sound_Video,Dialogue_Adjust,Dialogue_Lift</Define><Define
+        ID="P15">System,Sound_Video,HDMI,Video,Preset_Sel,Current</Define><Define
+        ID="P17">Main_Zone,Sound_Video,Direct,Mode</Define><Define ID="P18">Main_Zone,Cursor_Control,Cursor</Define><Define
+        ID="P19">Main_Zone,Cursor_Control,Menu_Control</Define><Define ID="P22">Main_Zone,Volume,Subwoofer_Trim</Define><Define
+        ID="P23">Main_Zone,Power_Control,Sleep</Define><Define ID="P24">Main_Zone,Play_Control,Playback</Define><Define
+        ID="P27">Main_Zone,Speaker_Preout,Speaker_AB,Speaker_A</Define><Define ID="P28">Main_Zone,Speaker_Preout,Speaker_AB,Speaker_B</Define><Define
+        ID="P29">Main_Zone,Sound_Video,Extra_Bass</Define><Define ID="P30">Main_Zone,Volume,Scale</Define><Define
+        ID="P32">Main_Zone,Cursor_Control,Contents_Display</Define><Define ID="G1">Main_Zone,Basic_Status</Define><Define
+        ID="G2">Main_Zone,Input,Input_Sel_Item</Define><Define ID="G3">Main_Zone,Config</Define><Define
+        ID="G4">Main_Zone,Scene,Scene_Sel_Item</Define><Define ID="G9">Main_Zone,Cursor_Control,Contents_Display</Define></Cmd_List></Menu><Menu
+        Func="Subunit" Title_1="Zone B" YNC_Tag="Main_Zone"><Menu Func="Status" Title_1="Availability"><Get><Cmd
+        ID="G1">Volume,Zone_B,Feature_Availability=Param_1</Cmd><Param_1><Direct Func="Status_Ready">Ready</Direct><Direct
+        Func="Status_Unavailable">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Rename"
+        Title_1="Name" List_Type="Text_Input"><Put_2><Cmd ID="P5">Param_1</Cmd><Param_1><Text>1,9,Latin-1</Text></Param_1></Put_2><Get><Cmd
+        ID="G3">Name,Zone_B=Param_1</Cmd><Param_1><Text>1,9,Latin-1</Text></Param_1></Get></Menu><Menu
+        Title_1="Input/Scene" List_Type="Icon"><Menu Func="Input" Func_Ex="Input"
+        Title_1="Input" List_Type="Icon" Icon_on="/YamahaRemoteControl/Icons/icon000.png"><Put_2><Cmd
+        ID="P4">Param_1</Cmd><Param_1><Indirect ID="G2"/></Param_1></Put_2><Get><Cmd
+        ID="G1">Input,Input_Sel=Param_1</Cmd><Param_1><Indirect ID="G2"/></Param_1></Get></Menu></Menu><Menu
+        Func="Vol" Title_1="Volume"><Menu Func="Vol_Lvl" List_Type="Slider" Title_1="Level"><Put_2><Cmd
+        Type="Number" ID="P2">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>-805,165,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number" ID="G1">Volume,Zone_B,Lvl,Val=Param_1:Volume,Zone_B,Lvl,Exp=Param_2:Volume,Zone_B,Lvl,Unit=Param_3</Cmd><Param_1><Range>-805,165,5</Range></Param_1><Param_2><Direct>1</Direct></Param_2><Param_3><Direct>dB</Direct></Param_3></Get></Menu><Menu
+        Func="Vol_Mute" Title_1="Mute"><Put_1 Func="Vol_Mute_On" ID="P3">On</Put_1><Put_1
+        Func="Vol_Mute_Off" ID="P3">Off</Put_1><Get><Cmd ID="G1">Volume,Zone_B,Mute=Param_1</Cmd><Param_1><Direct
+        Func="Vol_Mute_On">On</Direct><Direct Func="Vol_Mute_Off">Off</Direct></Param_1></Get></Menu><Menu
+        Func_Ex="Vol_Interlock" Title_1="Volume Interlock"><Put_1 Func_Ex="Vol_Interlock_On"
+        ID="P6">On</Put_1><Put_1 Func_Ex="Vol_Interlock_Off" ID="P6">Off</Put_1><Get><Cmd
+        ID="G1">Volume,Zone_B,Interlock=Param_1</Cmd><Param_1><Direct Func_Ex="Vol_Interlock_On">On</Direct><Direct
+        Func_Ex="Vol_Interlock_On">Off</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Power_Control" Title_1="Power Control"><Menu Func="Power" Title_1="Power"><Put_1
+        Func="Power_On" ID="P28">On</Put_1><Put_1 Func="Power_Standby" ID="P28">Off</Put_1><Get><Cmd
+        ID="G1">Power_Control,Zone_B_Power_Info=Param_1</Cmd><Param_1><Direct Func="Power_On">On</Direct><Direct
+        Func="Power_Standby">Standby</Direct></Param_1></Get></Menu></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1 ID="P24"
+        Layout="24" Func="Play">Play</Put_1><Put_1 ID="P24" Layout="23" Func="Pause">Pause</Put_1><Put_1
+        ID="P24" Layout="22" Func="Stop">Stop</Put_1></Menu><Menu Func="Plus_Minus"
+        Title_1="Skip"><Put_1 ID="P24" Layout="28" Func="Plus_1">Skip Fwd</Put_1><Put_1
+        ID="P24" Layout="27" Func="Minus_1">Skip Rev</Put_1></Menu></Menu><Menu Func="List_Control"
+        Title_1="List Control"><Menu Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1
+        ID="P18" Layout="5" Func="Cursor_Up">Up</Put_1><Put_1 ID="P18" Layout="9"
+        Func="Cursor_Down">Down</Put_1><Put_1 ID="P18" Layout="6" Func="Cursor_Left">Left</Put_1><Put_1
+        ID="P18" Layout="8" Func="Cursor_Right">Right</Put_1><Put_1 ID="P18" Layout="10"
+        Func="Cursor_Return">Return</Put_1><Put_1 ID="P18" Layout="7" Func="Cursor_Sel">Sel</Put_1><Put_1
+        ID="P18" Func="Cursor_Home">Return to Home</Put_1><Put_1 ID="P19" Layout="3"
+        Func="Cursor_Setup" Title_1="Setup">On Screen</Put_1><Put_1 ID="P19" Layout="4"
+        Func="Cursor_Option">Option</Put_1><Put_1 ID="P19" Layout="11" Func="Cursor_Display">Display</Put_1></Menu></Menu><Cmd_List><Define
+        ID="P1">Main_Zone,Power_Control,Power</Define><Define ID="P2">Main_Zone,Volume,Zone_B,Lvl</Define><Define
+        ID="P3">Main_Zone,Volume,Zone_B,Mute</Define><Define ID="P4">Main_Zone,Input,Input_Sel</Define><Define
+        ID="P5">Main_Zone,Config,Name,Zone_B</Define><Define ID="P6">Main_Zone,Volume,Zone_B,Interlock</Define><Define
+        ID="P18">Main_Zone,Cursor_Control,Cursor</Define><Define ID="P19">Main_Zone,Cursor_Control,Menu_Control</Define><Define
+        ID="P23">Main_Zone,Power_Control,Sleep</Define><Define ID="P24">Main_Zone,Play_Control,Playback</Define><Define
+        ID="P27">Main_Zone,Speaker_Preout,Speaker_AB,Speaker_A</Define><Define ID="P28">Main_Zone,Speaker_Preout,Speaker_AB,Speaker_B</Define><Define
+        ID="G1">Main_Zone,Basic_Status</Define><Define ID="G2">Main_Zone,Input,Input_Sel_Item</Define><Define
+        ID="G3">Main_Zone,Config</Define></Cmd_List></Menu><Menu Func="Source_Device"
+        Func_Ex="SD_Tuner" YNC_Tag="Tuner"><Menu Func="Status" Title_1="Device"><Get><Cmd
+        ID="G2">Feature_Availability=Param_1</Cmd><Param_1><Direct Func="Status_Ready">Ready</Direct><Direct
+        Func="Status_Not_Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Title_1="Up / Down"><Menu Func="Plus_Minus" Func_Ex="Freq_AM"
+        Title_1="AM Freq"><Put_1 ID="P11" Func="Plus_1">Auto Up</Put_1><Put_1 ID="P11"
+        Func="Minus_1">Auto Down</Put_1><Put_1 ID="P11" Func_Ex="Freq_Auto_Cancel">Cancel</Put_1><Get><Cmd
+        Type="Number_Ex" ID="G1">Tuning,Freq,AM,Val=Param_1:Tuning,Freq,AM,Exp=Param_2:Tuning,Freq,AM,Unit=Param_3</Cmd><Param_1><Range>530,1710,10</Range><Direct
+        Func_Ex="Freq_Auto_Up">Auto Up</Direct><Direct Func_Ex="Freq_Auto_Down">Auto
+        Down</Direct></Param_1><Param_2><Direct>0</Direct><Direct/><Direct/></Param_2><Param_3><Direct>kHz</Direct><Direct/><Direct/></Param_3></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Freq_FM" Title_1="FM Freq"><Put_1 ID="P10" Func="Plus_1">Auto
+        Up</Put_1><Put_1 ID="P10" Func="Minus_1">Auto Down</Put_1><Put_1 ID="P10"
+        Func_Ex="Freq_Auto_Cancel">Cancel</Put_1><Get><Cmd Type="Number_Ex" ID="G1">Tuning,Freq,FM,Val=Param_1:Tuning,Freq,FM,Exp=Param_2:Tuning,Freq,FM,Unit=Param_3</Cmd><Param_1><Range>8750,10790,20</Range><Direct
+        Func_Ex="Freq_Auto_Up">Auto Up</Direct><Direct Func_Ex="Freq_Auto_Down">Auto
+        Down</Direct></Param_1><Param_2><Direct>2</Direct><Direct/><Direct/></Param_2><Param_3><Direct>MHz</Direct><Direct/><Direct/></Param_3></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Preset" Title_1="Preset"><Put_1 ID="P2" Func="Plus_1">Up</Put_1><Put_1
+        ID="P2" Func="Minus_1">Down</Put_1><Get><Cmd ID="G1">Preset,Preset_Sel=Param_1</Cmd><Param_1><Indirect
+        ID="G3"/></Param_1></Get></Menu></Menu><Menu Func="Band" Title_1="Band"><Put_1
+        Func="Band_AM" ID="P3">AM</Put_1><Put_1 Func="Band_FM" ID="P3">FM</Put_1><Get><Cmd
+        ID="G1">Tuning,Band=Param_1</Cmd><Param_1><Direct Func="Band_AM">AM</Direct><Direct
+        Func="Band_FM">FM</Direct></Param_1></Get></Menu><Menu Title_1="Frequency"><Menu
+        Func="Freq" Func_Ex="Freq_AM" Title_1="AM" List_Type="Slider"><Put_2><Cmd
+        Type="Number_Ex" ID="P9">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>530,1710,10</Range></Param_1><Param_2><Direct>0</Direct></Param_2><Param_3><Direct>kHz</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number_Ex" ID="G1">Tuning,Freq,AM,Val=Param_1:Tuning,Freq,AM,Exp=Param_2:Tuning,Freq,AM,Unit=Param_3</Cmd><Param_1><Range>530,1710,10</Range><Direct
+        Func_Ex="Freq_Auto_Up">Auto Up</Direct><Direct Func_Ex="Freq_Auto_Down">Auto
+        Down</Direct></Param_1><Param_2><Direct>0</Direct><Direct/><Direct/></Param_2><Param_3><Direct>kHz</Direct><Direct/><Direct/></Param_3></Get></Menu><Menu
+        Func="Freq" Func_Ex="Freq_FM" Title_1="FM" List_Type="Slider"><Put_2><Cmd
+        Type="Number_Ex" ID="P8">Val=Param_1:Exp=Param_2:Unit=Param_3</Cmd><Param_1><Range>8750,10790,20</Range></Param_1><Param_2><Direct>2</Direct></Param_2><Param_3><Direct>MHz</Direct></Param_3></Put_2><Get><Cmd
+        Type="Number_Ex" ID="G1">Tuning,Freq,FM,Val=Param_1:Tuning,Freq,FM,Exp=Param_2:Tuning,Freq,FM,Unit=Param_3</Cmd><Param_1><Range>8750,10790,20</Range><Direct
+        Func_Ex="Freq_Auto_Up">Auto Up</Direct><Direct Func_Ex="Freq_Auto_Down">Auto
+        Down</Direct></Param_1><Param_2><Direct>2</Direct><Direct/><Direct/></Param_2><Param_3><Direct>MHz</Direct><Direct/><Direct/></Param_3></Get></Menu></Menu><Menu
+        Func="Preset" Title_1="Preset" List_Type="Slider"><Put_2><Cmd ID="P2">Param_1</Cmd><Param_1><Indirect
+        ID="G3"/></Param_1></Put_2><Get><Cmd ID="G1">Preset,Preset_Sel=Param_1</Cmd><Param_1><Indirect
+        ID="G3"/></Param_1></Get></Menu></Menu><Menu Func="Play_Info" List_Type="No_Pic"
+        Title_1="Play Info."><Menu Func="Band" Title_1="Band"><Get><Cmd ID="G1">Tuning,Band=Param_1</Cmd><Param_1><Direct
+        Func="Band_AM">AM</Direct><Direct Func="Band_FM">FM</Direct></Param_1></Get></Menu><Menu
+        Func="Freq" Func_Ex="Freq_AM_FM" Title_1="Frequency"><Get><Cmd Type="Number_Ex"
+        ID="G1">Tuning,Freq,Current,Val=Param_1:Tuning,Freq,Current,Exp=Param_2:Tuning,Freq,Current,Unit=Param_3</Cmd><Param_1><Range>530,1710,10</Range><Range>8750,10790,20</Range><Direct
+        Func_Ex="Freq_Auto_Up">Auto Up</Direct><Direct Func_Ex="Freq_Auto_Down">Auto
+        Down</Direct></Param_1><Param_2><Direct>0</Direct><Direct>2</Direct><Direct/><Direct/></Param_2><Param_3><Direct>kHz</Direct><Direct>MHz</Direct><Direct/><Direct/></Param_3></Get></Menu><Menu
+        Title_1="Status"><Menu Func_Ex="Tuned" Title_1="Tuned"><Get><Cmd ID="G1">Signal_Info,Tuned=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Tuned_Off" Title_1="Not Tuned">Negate</Direct><Direct Func_Ex="Tuned_On"
+        Title_1="Tuned">Assert</Direct></Param_1></Get></Menu><Menu Func_Ex="Stereo"
+        Title_1="Stereo"><Get><Cmd ID="G1">Signal_Info,Stereo=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Stereo_Off" Title_1="Mono">Negate</Direct><Direct Func_Ex="Stereo_On"
+        Title_1="Stereo">Assert</Direct></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">Tuner,Play_Control,Search_Mode</Define><Define ID="P2">Tuner,Play_Control,Preset,Preset_Sel</Define><Define
+        ID="P3">Tuner,Play_Control,Tuning,Band</Define><Define ID="P8">Tuner,Play_Control,Tuning,Freq,FM</Define><Define
+        ID="P9">Tuner,Play_Control,Tuning,Freq,AM</Define><Define ID="P10">Tuner,Play_Control,Tuning,Freq,FM,Val</Define><Define
+        ID="P11">Tuner,Play_Control,Tuning,Freq,AM,Val</Define><Define ID="G1">Tuner,Play_Info</Define><Define
+        ID="G2">Tuner,Config</Define><Define ID="G3">Tuner,Play_Control,Preset,Preset_Sel_Item</Define></Cmd_List></Menu><Menu
+        Func="Source_Device" Func_Ex="SD_AirPlay" YNC_Tag="AirPlay"><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1 Func="Play"
+        ID="P1">Play</Put_1><Put_1 Func="Pause" ID="P1">Pause</Put_1><Get><Cmd ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct
+        Func="Play">Play</Direct><Direct Func="Pause">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Title_1="Skip"><Put_1 Func="Plus_1" ID="P1">Skip
+        Fwd</Put_1><Put_1 Func="Minus_1" ID="P1">Skip Rev</Put_1></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Artist"
+        Title_1="Artist"><Get><Cmd ID="G1">Meta_Info,Artist=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Song"><Get><Cmd ID="G1">Meta_Info,Song=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Stop</Direct></Param_1></Get></Menu><Menu Func="Input_Logo_URL_S"
+        Title_1="Input Logo S URL"><Get><Cmd ID="G1">Input_Logo,URL_S=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu></Menu><Cmd_List><Define
+        ID="P1">AirPlay,Play_Control,Playback</Define><Define ID="G1">AirPlay,Play_Info</Define><Define
+        ID="G3">AirPlay,Config</Define></Cmd_List></Menu><Menu Func="Source_Device"
+        Func_Ex="SD_Spotify" YNC_Tag="Spotify"><Menu Func="Status" Title_1="Device"><Get><Cmd
+        ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct Func="Status_Ready">Ready</Direct><Direct
+        Func="Status_Not_Ready" Title_1="Not Ready">Not Ready</Direct></Param_1></Get></Menu><Menu
+        Func="Play_Control" Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1
+        Func="Play" ID="P1">Play</Put_1><Put_1 Func="Pause" ID="P1">Pause</Put_1><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Title_1="Skip"><Put_1 Func="Plus_1" ID="P1">Skip
+        Fwd</Put_1><Put_1 Func="Minus_1" ID="P1">Skip Rev</Put_1></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Artist"
+        Title_1="Artist"><Get><Cmd ID="G1">Meta_Info,Artist=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Track"><Get><Cmd ID="G1">Meta_Info,Track=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Input_Logo_URL_S" Title_1="Input Logo S URL"><Get><Cmd ID="G1">Input_Logo,URL_S=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu></Menu><Cmd_List><Define
+        ID="P1">Spotify,Play_Control,Playback</Define><Define ID="G1">Spotify,Play_Info</Define><Define
+        ID="G3">Spotify,Config</Define></Cmd_List></Menu><Menu Func="Source_Device"
+        Func_Ex="SD_iPod_USB" YNC_Tag="iPod_USB"><Menu Func="Init" Title_1="Initialize"><Put_1
+        Title_1="Browse Mode" ID="P10">Extended</Put_1></Menu><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Rep" Title_1="Repeat"><Put_1 Func="Rep_Off"
+        ID="P8">Off</Put_1><Put_1 Func="Rep_1" ID="P8">One</Put_1><Put_1 Func="Rep_2"
+        ID="P8">All</Put_1><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Put_1 Func="Rnd_Off" ID="P9">Off</Put_1><Put_1
+        Func="Rnd_1" ID="P9">Songs</Put_1><Put_1 Func="Rnd_2" ID="P9">Albums</Put_1><Get><Cmd
+        ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct Func="Rnd_Off">Off</Direct><Direct
+        Func="Rnd_1">Songs</Direct><Direct Func="Rnd_2">Albums</Direct></Param_1></Get></Menu><Menu
+        Func="Playback" Title_1="Play"><Put_1 Func="Play" ID="P1">Play</Put_1><Put_1
+        Func="Pause" ID="P1">Pause</Put_1><Put_1 Func="Stop" Playable="No" ID="P1">Stop</Put_1><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Playable="No" Title_1="Skip"><Put_1 Func="Plus_1"
+        ID="P1">Skip Fwd</Put_1><Put_1 Func="Minus_1" ID="P1">Skip Rev</Put_1></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Artist"
+        Title_1="Artist"><Get><Cmd ID="G1">Meta_Info,Artist=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Song"><Get><Cmd ID="G1">Meta_Info,Song=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Rep" Title_1="Repeat"><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Get><Cmd ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct
+        Func="Rnd_Off">Off</Direct><Direct Func="Rnd_1">Songs</Direct><Direct Func="Rnd_2">Albums</Direct></Param_1></Get></Menu><Menu
+        Func="Album_ART_URL" Title_1="AlbumART URL"><Get><Cmd ID="G1">Album_ART,URL=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album_ART_ID" Title_1="AlbumART ID"><Get><Cmd ID="G1">Album_ART,ID=Param_1</Cmd><Param_1><Range>0,255,1</Range></Param_1></Get></Menu><Menu
+        Func="Album_ART_Format" Title_1="AlbumART Format"><Get><Cmd ID="G1">Album_ART,Format=Param_1</Cmd><Param_1><Direct
+        Func="BMP">BMP</Direct><Direct Func="YMF">YMF</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="List_Browse" Title_1="List Browse"><Menu Func="List_Control" Title_1="List
+        Control"><Menu Func="Direct_Sel" Title_1="Direct Cursor Select"><Put_2><Cmd
+        ID="P2">Param_1</Cmd><Param_1><Range>1,8,1,Line_%</Range></Param_1></Put_2></Menu><Menu
+        Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1 ID="P5" Func="Cursor_Up">Up</Put_1><Put_1
+        ID="P5" Func="Cursor_Down">Down</Put_1><Put_1 ID="P5" Func="Cursor_Left">Return</Put_1><Put_1
+        ID="P5" Func="Cursor_Sel">Sel</Put_1><Put_1 ID="P5" Func="Cursor_Home">Return
+        to Home</Put_1></Menu><Menu Func="Jump_Line" Title_1="Jump Page"><Put_2><Cmd
+        ID="P4">Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Put_2></Menu><Menu
+        Func="Page_Up_Down" Title_1="Page"><Put_1 ID="P6" Func="Page_Up_1">Up</Put_1><Put_1
+        ID="P6" Func="Page_Down_1">Down</Put_1></Menu></Menu><Menu Func="List_Info"
+        Title_1="List Info."><Menu Func="Menu_Status" Title_1="Menu Status"><Get><Cmd
+        ID="G2">Menu_Status=Param_1</Cmd><Param_1><Direct Func="Menu_Status_Ready">Ready</Direct><Direct
+        Func="Menu_Status_Busy">Busy</Direct></Param_1></Get></Menu><Menu Func="Menu_Layer"
+        Title_1="Menu Layer"><Get><Cmd ID="G2">Menu_Layer=Param_1</Cmd><Param_1><Range>1,16,1</Range></Param_1></Get></Menu><Menu
+        Func="Menu_Name" Title_1="Menu Name"><Get><Cmd ID="G2">Menu_Name=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Menu_List" Title_1="Menu List"><Menu Func="Menu_Line" Title_1="Line
+        1"><Put_1 ID="P2">Line_1</Put_1><Get><Cmd Type="Container" ID="G2">Current_List,Line_1,Txt=Param_1:Current_List,Line_1,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 2"><Put_1 ID="P2">Line_2</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_2,Txt=Param_1:Current_List,Line_2,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 3"><Put_1 ID="P2">Line_3</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_3,Txt=Param_1:Current_List,Line_3,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 4"><Put_1 ID="P2">Line_4</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_4,Txt=Param_1:Current_List,Line_4,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 5"><Put_1 ID="P2">Line_5</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_5,Txt=Param_1:Current_List,Line_5,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 6"><Put_1 ID="P2">Line_6</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_6,Txt=Param_1:Current_List,Line_6,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 7"><Put_1 ID="P2">Line_7</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_7,Txt=Param_1:Current_List,Line_7,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 8"><Put_1 ID="P2">Line_8</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_8,Txt=Param_1:Current_List,Line_8,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu></Menu><Menu
+        Func="Current_Line" Title_1="Cursor Line"><Get><Cmd ID="G2">Cursor_Position,Current_Line=Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Get></Menu><Menu
+        Func="Max_Line" Title_1="Max. Line"><Get><Cmd ID="G2">Cursor_Position,Max_Line=Param_1</Cmd><Param_1><Range>0,65536,1</Range></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">iPod_USB,Play_Control,Playback</Define><Define ID="P2">iPod_USB,List_Control,Direct_Sel</Define><Define
+        ID="P4">iPod_USB,List_Control,Jump_Line</Define><Define ID="P5">iPod_USB,List_Control,Cursor</Define><Define
+        ID="P6">iPod_USB,List_Control,Page</Define><Define ID="P8">iPod_USB,Play_Control,Play_Mode,Repeat</Define><Define
+        ID="P9">iPod_USB,Play_Control,Play_Mode,Shuffle</Define><Define ID="P10">iPod_USB,Play_Control,iPod_Mode</Define><Define
+        ID="G1">iPod_USB,Play_Info</Define><Define ID="G2">iPod_USB,List_Info</Define><Define
+        ID="G3">iPod_USB,Config</Define></Cmd_List></Menu><Menu Func="Source_Device"
+        Func_Ex="SD_USB" YNC_Tag="USB"><Menu Func="Status" Title_1="Device"><Get><Cmd
+        ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct Func="Status_Ready">Ready</Direct><Direct
+        Func="Status_Not_Ready" Title_1="Not Ready">Not Ready</Direct></Param_1></Get></Menu><Menu
+        Func="Play_Control" Title_1="Play Control"><Menu Func="Rep" Title_1="Repeat"><Put_1
+        Func="Rep_Off" ID="P1">Off</Put_1><Put_1 Func="Rep_1" ID="P1">One</Put_1><Put_1
+        Func="Rep_2" ID="P1">All</Put_1><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Put_1 Func="Rnd_Off" ID="P2">Off</Put_1><Put_1
+        Func="Rnd_1" ID="P2">On</Put_1><Get><Cmd ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct
+        Func="Rnd_Off">Off</Direct><Direct Func="Rnd_1">On</Direct></Param_1></Get></Menu><Menu
+        Func="Playback" Title_1="Play"><Put_1 ID="P3" Func="Play">Play</Put_1><Put_1
+        ID="P3" Func="Pause">Pause</Put_1><Put_1 ID="P3" Playable="No" Func="Stop">Stop</Put_1><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Playable="No" Title_1="Skip"><Put_1 ID="P3"
+        Func="Plus_1">Skip Fwd</Put_1><Put_1 ID="P3" Func="Minus_1">Skip Rev</Put_1></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Artist"
+        Title_1="Artist"><Get><Cmd ID="G1">Meta_Info,Artist=Param_1</Cmd><Param_1><Text>0,64,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,64,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Song"><Get><Cmd ID="G1">Meta_Info,Song=Param_1</Cmd><Param_1><Text>0,64,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G1">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Rep" Title_1="Repeat"><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Get><Cmd ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct
+        Func="Rnd_Off">Off</Direct><Direct Func="Rnd_1">On</Direct></Param_1></Get></Menu><Menu
+        Func="Album_ART_URL" Title_1="AlbumART URL"><Get><Cmd ID="G1">Album_ART,URL=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album_ART_ID" Title_1="AlbumART ID"><Get><Cmd ID="G1">Album_ART,ID=Param_1</Cmd><Param_1><Range>0,255,1</Range></Param_1></Get></Menu><Menu
+        Func="Album_ART_Format" Title_1="AlbumART Format"><Get><Cmd ID="G1">Album_ART,Format=Param_1</Cmd><Param_1><Direct
+        Func="BMP">BMP</Direct><Direct Func="YMF">YMF</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="List_Browse" Title_1="List Browse"><Menu Func="List_Control" Title_1="List
+        Control"><Menu Func="Direct_Sel" Title_1="Direct Cursor Select"><Put_2><Cmd
+        ID="P5">Param_1</Cmd><Param_1><Range>1,8,1,Line_%</Range></Param_1></Put_2></Menu><Menu
+        Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1 ID="P7" Func="Cursor_Up">Up</Put_1><Put_1
+        ID="P7" Func="Cursor_Down">Down</Put_1><Put_1 ID="P7" Func="Cursor_Left">Return</Put_1><Put_1
+        ID="P7" Func="Cursor_Sel">Sel</Put_1><Put_1 ID="P7" Func="Cursor_Home">Return
+        to Home</Put_1></Menu><Menu Func="Jump_Line" Title_1="Jump Page"><Put_2><Cmd
+        ID="P6">Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Put_2></Menu><Menu
+        Func="Page_Up_Down" Title_1="Page"><Put_1 ID="P8" Func="Page_Up_1">Up</Put_1><Put_1
+        ID="P8" Func="Page_Down_1">Down</Put_1></Menu></Menu><Menu Func="List_Info"
+        Title_1="List Info."><Menu Func="Menu_Status" Title_1="Menu Status"><Get><Cmd
+        ID="G2">Menu_Status=Param_1</Cmd><Param_1><Direct Func="Menu_Status_Ready">Ready</Direct><Direct
+        Func="Menu_Status_Busy">Busy</Direct></Param_1></Get></Menu><Menu Func="Menu_Layer"
+        Title_1="Menu Layer"><Get><Cmd ID="G2">Menu_Layer=Param_1</Cmd><Param_1><Range>1,16,1</Range></Param_1></Get></Menu><Menu
+        Func="Menu_Name" Title_1="Menu Name"><Get><Cmd ID="G2">Menu_Name=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Menu_List" Title_1="Menu List"><Menu Func="Menu_Line" Title_1="Line
+        1"><Put_1 ID="P5">Line_1</Put_1><Get><Cmd Type="Container" ID="G2">Current_List,Line_1,Txt=Param_1:Current_List,Line_1,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 2"><Put_1 ID="P5">Line_2</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_2,Txt=Param_1:Current_List,Line_2,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 3"><Put_1 ID="P5">Line_3</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_3,Txt=Param_1:Current_List,Line_3,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 4"><Put_1 ID="P5">Line_4</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_4,Txt=Param_1:Current_List,Line_4,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 5"><Put_1 ID="P5">Line_5</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_5,Txt=Param_1:Current_List,Line_5,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 6"><Put_1 ID="P5">Line_6</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_6,Txt=Param_1:Current_List,Line_6,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 7"><Put_1 ID="P5">Line_7</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_7,Txt=Param_1:Current_List,Line_7,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 8"><Put_1 ID="P5">Line_8</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_8,Txt=Param_1:Current_List,Line_8,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu></Menu><Menu
+        Func="Current_Line" Title_1="Cursor Line"><Get><Cmd ID="G2">Cursor_Position,Current_Line=Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Get></Menu><Menu
+        Func="Max_Line" Title_1="Max. Line"><Get><Cmd ID="G2">Cursor_Position,Max_Line=Param_1</Cmd><Param_1><Range>0,65536,1</Range></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">USB,Play_Control,Play_Mode,Repeat</Define><Define ID="P2">USB,Play_Control,Play_Mode,Shuffle</Define><Define
+        ID="P3">USB,Play_Control,Playback</Define><Define ID="P4">USB,Play_Control,Preset,Preset_Sel</Define><Define
+        ID="P5">USB,List_Control,Direct_Sel</Define><Define ID="P6">USB,List_Control,Jump_Line</Define><Define
+        ID="P7">USB,List_Control,Cursor</Define><Define ID="P8">USB,List_Control,Page</Define><Define
+        ID="G1">USB,Play_Info</Define><Define ID="G2">USB,List_Info</Define><Define
+        ID="G3">USB,Config</Define><Define ID="G4">USB,Play_Control,Preset,Preset_Sel_Item</Define></Cmd_List></Menu><Menu
+        Func="Source_Device" Func_Ex="SD_vTuner" YNC_Tag="NET_RADIO"><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1 ID="P1"
+        Func="Play">Play</Put_1><Put_1 ID="P1" Func="Stop">Stop</Put_1><Get><Cmd ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct
+        Func="Play">Play</Direct><Direct Func="Stop">Stop</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Station"
+        Title_1="Station"><Get><Cmd ID="G1">Meta_Info,Station=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Song"><Get><Cmd ID="G1">Meta_Info,Song=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G1">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu Func="Album_ART_URL"
+        Title_1="AlbumART URL"><Get><Cmd ID="G1">Album_ART,URL=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album_ART_ID" Title_1="AlbumART ID"><Get><Cmd ID="G1">Album_ART,ID=Param_1</Cmd><Param_1><Range>0,255,1</Range></Param_1></Get></Menu><Menu
+        Func="Album_ART_Format" Title_1="AlbumART Format"><Get><Cmd ID="G1">Album_ART,Format=Param_1</Cmd><Param_1><Direct
+        Func="BMP">BMP</Direct><Direct Func="YMF">YMF</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="List_Browse" Title_1="List Browse"><Menu Func="List_Control" Title_1="List
+        Control"><Menu Func="Direct_Sel" Title_1="Direct Cursor Select"><Put_2><Cmd
+        ID="P2">Param_1</Cmd><Param_1><Range>1,8,1,Line_%</Range></Param_1></Put_2></Menu><Menu
+        Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1 ID="P4" Func="Cursor_Up">Up</Put_1><Put_1
+        ID="P4" Func="Cursor_Down">Down</Put_1><Put_1 ID="P4" Func="Cursor_Left">Return</Put_1><Put_1
+        ID="P4" Func="Cursor_Sel">Sel</Put_1><Put_1 ID="P4" Func="Cursor_Home">Return
+        to Home</Put_1></Menu><Menu Func="Jump_Line" Title_1="Jump Page"><Put_2><Cmd
+        ID="P3">Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Put_2></Menu><Menu
+        Func="Page_Up_Down" Title_1="Page"><Put_1 ID="P5" Func="Page_Up_1">Up</Put_1><Put_1
+        ID="P5" Func="Page_Down_1">Down</Put_1></Menu><Menu Func="Bookmark" Title_1="Bookmark"><Put_1
+        ID="P7" Func="Bookmark_On">On</Put_1><Put_1 ID="P7" Func="Bookmark_Off">Off</Put_1></Menu></Menu><Menu
+        Func="List_Info" Title_1="List Info."><Menu Func="Menu_Status" Title_1="Menu
+        Status"><Get><Cmd ID="G2">Menu_Status=Param_1</Cmd><Param_1><Direct Func="Menu_Status_Ready">Ready</Direct><Direct
+        Func="Menu_Status_Busy">Busy</Direct></Param_1></Get></Menu><Menu Func="Menu_Layer"
+        Title_1="Menu Layer"><Get><Cmd ID="G2">Menu_Layer=Param_1</Cmd><Param_1><Range>1,16,1</Range></Param_1></Get></Menu><Menu
+        Func="Menu_Name" Title_1="Menu Name"><Get><Cmd ID="G2">Menu_Name=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Menu_List" Title_1="Menu List"><Menu Func="Menu_Line" Title_1="Line
+        1"><Put_1 ID="P2">Line_1</Put_1><Get><Cmd Type="Container" ID="G2">Current_List,Line_1,Txt=Param_1:Current_List,Line_1,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 2"><Put_1 ID="P2">Line_2</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_2,Txt=Param_1:Current_List,Line_2,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 3"><Put_1 ID="P2">Line_3</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_3,Txt=Param_1:Current_List,Line_3,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 4"><Put_1 ID="P2">Line_4</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_4,Txt=Param_1:Current_List,Line_4,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 5"><Put_1 ID="P2">Line_5</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_5,Txt=Param_1:Current_List,Line_5,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 6"><Put_1 ID="P2">Line_6</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_6,Txt=Param_1:Current_List,Line_6,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 7"><Put_1 ID="P2">Line_7</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_7,Txt=Param_1:Current_List,Line_7,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 8"><Put_1 ID="P2">Line_8</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_8,Txt=Param_1:Current_List,Line_8,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu></Menu><Menu
+        Func="Current_Line" Title_1="Cursor Line"><Get><Cmd ID="G2">Cursor_Position,Current_Line=Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Get></Menu><Menu
+        Func="Max_Line" Title_1="Max. Line"><Get><Cmd ID="G2">Cursor_Position,Max_Line=Param_1</Cmd><Param_1><Range>0,65536,1</Range></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">NET_RADIO,Play_Control,Playback</Define><Define ID="P2">NET_RADIO,List_Control,Direct_Sel</Define><Define
+        ID="P3">NET_RADIO,List_Control,Jump_Line</Define><Define ID="P4">NET_RADIO,List_Control,Cursor</Define><Define
+        ID="P5">NET_RADIO,List_Control,Page</Define><Define ID="P6">NET_RADIO,Play_Control,Preset,Preset_Sel</Define><Define
+        ID="P7">NET_RADIO,List_Control,Bookmark</Define><Define ID="G1">NET_RADIO,Play_Info</Define><Define
+        ID="G2">NET_RADIO,List_Info</Define><Define ID="G3">NET_RADIO,Config</Define><Define
+        ID="G4">NET_RADIO,Play_Control,Preset,Preset_Sel_Item</Define></Cmd_List></Menu><Menu
+        Func="Source_Device" Func_Ex="SD_DLNA" YNC_Tag="SERVER"><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Rep" Title_1="Repeat"><Put_1 Func="Rep_Off"
+        ID="P1">Off</Put_1><Put_1 Func="Rep_1" ID="P1">One</Put_1><Put_1 Func="Rep_2"
+        ID="P1">All</Put_1><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Put_1 Func="Rnd_Off" ID="P2">Off</Put_1><Put_1
+        Func="Rnd_1" ID="P2">On</Put_1><Get><Cmd ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct
+        Func="Rnd_Off">Off</Direct><Direct Func="Rnd_1">On</Direct></Param_1></Get></Menu><Menu
+        Func="Playback" Title_1="Play"><Put_1 ID="P3" Func="Play">Play</Put_1><Put_1
+        ID="P3" Func="Pause">Pause</Put_1><Put_1 ID="P3" Playable="No" Func="Stop">Stop</Put_1><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Playable="No" Title_1="Skip"><Put_1 ID="P3"
+        Func="Plus_1">Skip Fwd</Put_1><Put_1 ID="P3" Func="Minus_1">Skip Rev</Put_1></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Artist"
+        Title_1="Artist"><Get><Cmd ID="G1">Meta_Info,Artist=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Song"><Get><Cmd ID="G1">Meta_Info,Song=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Status" Title_1="Device"><Get><Cmd ID="G1">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Playable="No" Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Rep" Title_1="Repeat"><Get><Cmd ID="G1">Play_Mode,Repeat=Param_1</Cmd><Param_1><Direct
+        Func="Rep_Off">Off</Direct><Direct Func="Rep_1">One</Direct><Direct Func="Rep_2">All</Direct></Param_1></Get></Menu><Menu
+        Func="Rnd" Title_1="Shuffle"><Get><Cmd ID="G1">Play_Mode,Shuffle=Param_1</Cmd><Param_1><Direct
+        Func="Rnd_Off">Off</Direct><Direct Func="Rnd_1">On</Direct></Param_1></Get></Menu><Menu
+        Func="Album_ART_URL" Title_1="AlbumART URL"><Get><Cmd ID="G1">Album_ART,URL=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album_ART_ID" Title_1="AlbumART ID"><Get><Cmd ID="G1">Album_ART,ID=Param_1</Cmd><Param_1><Range>0,255,1</Range></Param_1></Get></Menu><Menu
+        Func="Album_ART_Format" Title_1="AlbumART Format"><Get><Cmd ID="G1">Album_ART,Format=Param_1</Cmd><Param_1><Direct
+        Func="BMP">BMP</Direct><Direct Func="YMF">YMF</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="List_Browse" Title_1="List Browse"><Menu Func="List_Control" Title_1="List
+        Control"><Menu Func="Direct_Sel" Title_1="Direct Cursor Select"><Put_2><Cmd
+        ID="P5">Param_1</Cmd><Param_1><Range>1,8,1,Line_%</Range></Param_1></Put_2></Menu><Menu
+        Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1 ID="P7" Func="Cursor_Up">Up</Put_1><Put_1
+        ID="P7" Func="Cursor_Down">Down</Put_1><Put_1 ID="P7" Func="Cursor_Left">Return</Put_1><Put_1
+        ID="P7" Func="Cursor_Sel">Sel</Put_1><Put_1 ID="P7" Func="Cursor_Home">Return
+        to Home</Put_1></Menu><Menu Func="Jump_Line" Title_1="Jump Page"><Put_2><Cmd
+        ID="P6">Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Put_2></Menu><Menu
+        Func="Page_Up_Down" Title_1="Page"><Put_1 ID="P8" Func="Page_Up_1">Up</Put_1><Put_1
+        ID="P8" Func="Page_Down_1">Down</Put_1></Menu></Menu><Menu Func="List_Info"
+        Title_1="List Info."><Menu Func="Menu_Status" Title_1="Menu Status"><Get><Cmd
+        ID="G2">Menu_Status=Param_1</Cmd><Param_1><Direct Func="Menu_Status_Ready">Ready</Direct><Direct
+        Func="Menu_Status_Busy">Busy</Direct></Param_1></Get></Menu><Menu Func="Menu_Layer"
+        Title_1="Menu Layer"><Get><Cmd ID="G2">Menu_Layer=Param_1</Cmd><Param_1><Range>1,16,1</Range></Param_1></Get></Menu><Menu
+        Func="Menu_Name" Title_1="Menu Name"><Get><Cmd ID="G2">Menu_Name=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Menu_List" Title_1="Menu List"><Menu Func="Menu_Line" Title_1="Line
+        1"><Put_1 ID="P5">Line_1</Put_1><Get><Cmd Type="Container" ID="G2">Current_List,Line_1,Txt=Param_1:Current_List,Line_1,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 2"><Put_1 ID="P5">Line_2</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_2,Txt=Param_1:Current_List,Line_2,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 3"><Put_1 ID="P5">Line_3</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_3,Txt=Param_1:Current_List,Line_3,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 4"><Put_1 ID="P5">Line_4</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_4,Txt=Param_1:Current_List,Line_4,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 5"><Put_1 ID="P5">Line_5</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_5,Txt=Param_1:Current_List,Line_5,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 6"><Put_1 ID="P5">Line_6</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_6,Txt=Param_1:Current_List,Line_6,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 7"><Put_1 ID="P5">Line_7</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_7,Txt=Param_1:Current_List,Line_7,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 8"><Put_1 ID="P5">Line_8</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_8,Txt=Param_1:Current_List,Line_8,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu></Menu><Menu
+        Func="Current_Line" Title_1="Cursor Line"><Get><Cmd ID="G2">Cursor_Position,Current_Line=Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Get></Menu><Menu
+        Func="Max_Line" Title_1="Max. Line"><Get><Cmd ID="G2">Cursor_Position,Max_Line=Param_1</Cmd><Param_1><Range>0,65536,1</Range></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P1">SERVER,Play_Control,Play_Mode,Repeat</Define><Define ID="P2">SERVER,Play_Control,Play_Mode,Shuffle</Define><Define
+        ID="P3">SERVER,Play_Control,Playback</Define><Define ID="P4">SERVER,Play_Control,Preset,Preset_Sel</Define><Define
+        ID="P5">SERVER,List_Control,Direct_Sel</Define><Define ID="P6">SERVER,List_Control,Jump_Line</Define><Define
+        ID="P7">SERVER,List_Control,Cursor</Define><Define ID="P8">SERVER,List_Control,Page</Define><Define
+        ID="P9">SERVER,Play_Control,Play_URI</Define><Define ID="G1">SERVER,Play_Info</Define><Define
+        ID="G2">SERVER,List_Info</Define><Define ID="G3">SERVER,Config</Define><Define
+        ID="G4">SERVER,Play_Control,Preset,Preset_Sel_Item</Define></Cmd_List></Menu><Menu
+        Func="Source_Device" Func_Ex="SD_Pandora" YNC_Tag="Pandora"><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G3">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Play_Control"
+        Title_1="Play Control"><Menu Func="Playback" Title_1="Play"><Put_1 ID="P3"
+        Func="Play">Play</Put_1><Put_1 ID="P3" Func="Pause">Pause</Put_1><Put_1 ID="P3"
+        Func="Stop">Stop</Put_1><Get><Cmd ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct
+        Func="Play">Play</Direct><Direct Func="Pause">Pause</Direct><Direct Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Plus_Minus" Func_Ex="Song" Title_1="Skip"><Put_1 ID="P3" Func="Plus_1">Skip
+        Fwd</Put_1></Menu><Menu Func_Ex="Feedback" Title_1="Your Rating"><Put_1 ID="P2"
+        Func_Ex="Thumb_Up">Thumb Up</Put_1><Put_1 ID="P2" Func_Ex="Thumb_Down">Thumb
+        Down</Put_1><Get><Cmd ID="G1">Feedback=Param_1</Cmd><Param_1><Direct Func_Ex="Thumb_None">---</Direct><Direct
+        Func_Ex="Thumb_Up">Thumb Up</Direct><Direct Func_Ex="Thumb_Down">Thumb Down</Direct></Param_1></Get></Menu></Menu><Menu
+        Func="Play_Info" List_Type="With_Pic" Title_1="Play Info."><Menu Func="Station"
+        Title_1="Station"><Get><Cmd ID="G1">Meta_Info,Station=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album" Title_1="Album"><Get><Cmd ID="G1">Meta_Info,Album=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Song" Title_1="Track"><Get><Cmd ID="G1">Meta_Info,Track=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func_Ex="Feedback" Title_1="Your Rating"><Get><Cmd ID="G1">Feedback=Param_1</Cmd><Param_1><Direct
+        Func_Ex="Thumb_None">---</Direct><Direct Func_Ex="Thumb_Up">Thumb Up</Direct><Direct
+        Func_Ex="Thumb_Down">Thumb Down</Direct></Param_1></Get></Menu><Menu Func="Status"
+        Title_1="Device"><Get><Cmd ID="G1">Feature_Availability=Param_1</Cmd><Param_1><Direct
+        Func="Status_Ready">Ready</Direct><Direct Func="Status_Not_Ready" Title_1="Not
+        Ready">Not Ready</Direct></Param_1></Get></Menu><Menu Func="Playback" Title_1="Status"><Get><Cmd
+        ID="G1">Playback_Info=Param_1</Cmd><Param_1><Direct Func="Play">Play</Direct><Direct
+        Func="Pause">Pause</Direct><Direct Func="Stop">Stop</Direct></Param_1></Get></Menu><Menu
+        Func="Album_ART_URL" Title_1="AlbumART URL"><Get><Cmd ID="G1">Album_ART,URL=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Album_ART_ID" Title_1="AlbumART ID"><Get><Cmd ID="G1">Album_ART,ID=Param_1</Cmd><Param_1><Range>0,255,1</Range></Param_1></Get></Menu><Menu
+        Func="Album_ART_Format" Title_1="AlbumART Format"><Get><Cmd ID="G1">Album_ART,Format=Param_1</Cmd><Param_1><Direct
+        Func="BMP">BMP</Direct><Direct Func="YMF">YMF</Direct></Param_1></Get></Menu><Menu
+        Func="Input_Logo_URL_S" Title_1="Input Logo S URL"><Get><Cmd ID="G1">Input_Logo,URL_S=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu></Menu><Menu
+        Func="List_Browse" Title_1="List Browse"><Menu Func="List_Control" Title_1="List
+        Control"><Menu Func="Direct_Sel" Title_1="Direct Cursor Select"><Put_2><Cmd
+        ID="P5">Param_1</Cmd><Param_1><Range>1,8,1,Line_%</Range></Param_1></Put_2></Menu><Menu
+        Func="Cursor" List_Type="Cursor" Title_1="Cursor"><Put_1 ID="P7" Func="Cursor_Up">Up</Put_1><Put_1
+        ID="P7" Func="Cursor_Down">Down</Put_1><Put_1 ID="P7" Func="Cursor_Left">Return</Put_1><Put_1
+        ID="P7" Func="Cursor_Sel">Sel</Put_1><Put_1 ID="P7" Func="Cursor_Home">Return
+        to Home</Put_1></Menu><Menu Func="Jump_Line" Title_1="Jump Page"><Put_2><Cmd
+        ID="P6">Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Put_2></Menu><Menu
+        Func="Page_Up_Down" Title_1="Page"><Put_1 ID="P8" Func="Page_Up_1">Up</Put_1><Put_1
+        ID="P8" Func="Page_Down_1">Down</Put_1></Menu></Menu><Menu Func="List_Info"
+        Title_1="List Info."><Menu Func="Menu_Status" Title_1="Menu Status"><Get><Cmd
+        ID="G2">Menu_Status=Param_1</Cmd><Param_1><Direct Func="Menu_Status_Ready">Ready</Direct><Direct
+        Func="Menu_Status_Busy">Busy</Direct></Param_1></Get></Menu><Menu Func="Menu_Layer"
+        Title_1="Menu Layer"><Get><Cmd ID="G2">Menu_Layer=Param_1</Cmd><Param_1><Range>1,16,1</Range></Param_1></Get></Menu><Menu
+        Func="Menu_Name" Title_1="Menu Name"><Get><Cmd ID="G2">Menu_Name=Param_1</Cmd><Param_1><Text>0,128,UTF-8</Text></Param_1></Get></Menu><Menu
+        Func="Menu_List" Title_1="Menu List"><Menu Func="Menu_Line" Title_1="Line
+        1"><Put_1 ID="P5">Line_1</Put_1><Get><Cmd Type="Container" ID="G2">Current_List,Line_1,Txt=Param_1:Current_List,Line_1,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 2"><Put_1 ID="P5">Line_2</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_2,Txt=Param_1:Current_List,Line_2,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 3"><Put_1 ID="P5">Line_3</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_3,Txt=Param_1:Current_List,Line_3,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 4"><Put_1 ID="P5">Line_4</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_4,Txt=Param_1:Current_List,Line_4,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 5"><Put_1 ID="P5">Line_5</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_5,Txt=Param_1:Current_List,Line_5,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 6"><Put_1 ID="P5">Line_6</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_6,Txt=Param_1:Current_List,Line_6,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 7"><Put_1 ID="P5">Line_7</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_7,Txt=Param_1:Current_List,Line_7,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu><Menu
+        Func="Menu_Line" Title_1="Line 8"><Put_1 ID="P5">Line_8</Put_1><Get><Cmd Type="Container"
+        ID="G2">Current_List,Line_8,Txt=Param_1:Current_List,Line_8,Attribute=Param_2</Cmd><Param_1
+        Func="Menu_Txt"><Text>0,128,UTF-8</Text></Param_1><Param_2 Func="Menu_Type"><Direct
+        Func="Menu_Next">Container</Direct><Direct Func="Menu_Stay">Unplayable Item</Direct><Direct
+        Func="Menu_Play">Item</Direct><Direct Func="Menu_Prohibit">Unselectable</Direct></Param_2></Get></Menu></Menu><Menu
+        Func="Current_Line" Title_1="Cursor Line"><Get><Cmd ID="G2">Cursor_Position,Current_Line=Param_1</Cmd><Param_1><Range>1,65536,1</Range></Param_1></Get></Menu><Menu
+        Func="Max_Line" Title_1="Max. Line"><Get><Cmd ID="G2">Cursor_Position,Max_Line=Param_1</Cmd><Param_1><Range>0,65536,1</Range></Param_1></Get></Menu></Menu></Menu><Cmd_List><Define
+        ID="P2">Pandora,Play_Control,Feedback</Define><Define ID="P3">Pandora,Play_Control,Playback</Define><Define
+        ID="P4">Pandora,Play_Control,Preset,Preset_Sel</Define><Define ID="P5">Pandora,List_Control,Direct_Sel</Define><Define
+        ID="P6">Pandora,List_Control,Jump_Line</Define><Define ID="P7">Pandora,List_Control,Cursor</Define><Define
+        ID="P8">Pandora,List_Control,Page</Define><Define ID="G1">Pandora,Play_Info</Define><Define
+        ID="G2">Pandora,List_Info</Define><Define ID="G3">Pandora,Config</Define><Define
+        ID="G4">Pandora,Play_Control,Preset,Preset_Sel_Item</Define></Cmd_List></Menu></Unit_Description>
+    headers:
+      Content-Language:
+      - en
+      Content-Length:
+      - '76367'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_RX_V577/test_basic_status.yaml
+++ b/tests/integration/cassettes/test_RX_V577/test_basic_status.yaml
@@ -1,0 +1,66 @@
+interactions:
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Basic_Status>GetParam</Basic_Status></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Basic_Status><Power_Control><Power>On</Power><Zone_B_Power_Info>Standby</Zone_B_Power_Info><Sleep>Off</Sleep></Power_Control><Volume><Lvl><Val>-510</Val><Exp>1</Exp><Unit>dB</Unit></Lvl><Mute>Off</Mute><Subwoofer_Trim><Val>0</Val><Exp>1</Exp><Unit>dB</Unit></Subwoofer_Trim><Scale>dB</Scale><Zone_B><Feature_Availability>Not
+        Ready</Feature_Availability><Interlock>On</Interlock><Lvl><Val>-510</Val><Exp>1</Exp><Unit>dB</Unit></Lvl><Mute>Off</Mute></Zone_B></Volume><Input><Input_Sel>NET
+        RADIO</Input_Sel><Input_Sel_Item_Info><Param>NET RADIO</Param><RW>RW</RW><Title>NET
+        RADIO</Title><Icon><On>/YamahaRemoteControl/Icons/icon005.png</On><Off></Off></Icon><Src_Name>NET_RADIO</Src_Name><Src_Number>1</Src_Number></Input_Sel_Item_Info></Input><Surround><Program_Sel><Current><Straight>Off</Straight><Enhancer>On</Enhancer><Sound_Program>7ch
+        Stereo</Sound_Program></Current></Program_Sel><_3D_Cinema_DSP>Auto</_3D_Cinema_DSP></Surround><Sound_Video><Tone><Bass><Val>0</Val><Exp>1</Exp><Unit>dB</Unit></Bass><Treble><Val>0</Val><Exp>1</Exp><Unit>dB</Unit></Treble></Tone><Direct><Mode>Off</Mode></Direct><HDMI><Standby_Through_Info>On</Standby_Through_Info><Output><OUT_1>On</OUT_1></Output></HDMI><Extra_Bass>Off</Extra_Bass><Adaptive_DRC>Off</Adaptive_DRC></Sound_Video><Speaker_Preout><Speaker_AB><Speaker_A>On</Speaker_A><Speaker_B>Off</Speaker_B></Speaker_AB></Speaker_Preout></Basic_Status></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '1456'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_RX_V577/test_fade.yaml
+++ b/tests/integration/cassettes/test_RX_V577/test_fade.yaml
@@ -1,0 +1,362 @@
+interactions:
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-500</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Volume><Lvl>GetParam</Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Volume><Lvl><Val>-500</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '133'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-500</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-490</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-480</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Volume><Lvl>GetParam</Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Volume><Lvl><Val>-480</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '133'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Volume><Lvl>GetParam</Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Volume><Lvl><Val>-480</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '133'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-480</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-490</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-500</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Volume><Lvl><Val>-510</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '126'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Volume><Lvl></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Volume><Lvl>GetParam</Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Volume><Lvl><Val>-510</Val><Exp>1</Exp><Unit>dB</Unit></Lvl></Volume></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '133'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_RX_V577/test_inputs.yaml
+++ b/tests/integration/cassettes/test_RX_V577/test_inputs.yaml
@@ -1,0 +1,190 @@
+interactions:
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel_Item>GetParam</Input_Sel_Item></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel_Item><Item_1><Param>Pandora</Param><RW>RW</RW><Title>
+        Pandora </Title><Icon><On>/YamahaRemoteControl/Icons/icon075.png</On><Off></Off></Icon><Src_Name>Pandora</Src_Name><Src_Number>1</Src_Number></Item_1><Item_2><Param>Spotify</Param><RW>RW</RW><Title>
+        Spotify </Title><Icon><On>/YamahaRemoteControl/Icons/icon102.png</On><Off></Off></Icon><Src_Name>Spotify</Src_Name><Src_Number>1</Src_Number></Item_2><Item_3><Param>AirPlay</Param><RW>RW</RW><Title>
+        AirPlay </Title><Icon><On>/YamahaRemoteControl/Icons/icon067.png</On><Off></Off></Icon><Src_Name>AirPlay</Src_Name><Src_Number>1</Src_Number></Item_3><Item_4><Param>SERVER</Param><RW>RW</RW><Title>
+        SERVER  </Title><Icon><On>/YamahaRemoteControl/Icons/icon006.png</On><Off></Off></Icon><Src_Name>SERVER</Src_Name><Src_Number>1</Src_Number></Item_4><Item_5><Param>NET
+        RADIO</Param><RW>RW</RW><Title>NET RADIO</Title><Icon><On>/YamahaRemoteControl/Icons/icon005.png</On><Off></Off></Icon><Src_Name>NET_RADIO</Src_Name><Src_Number>1</Src_Number></Item_5><Item_6><Param>USB</Param><RW>RW</RW><Title>   USB   </Title><Icon><On>/YamahaRemoteControl/Icons/icon009.png</On><Off></Off></Icon><Src_Name>USB</Src_Name><Src_Number>1</Src_Number></Item_6><Item_7><Param>iPod
+        (USB)</Param><RW>R</RW><Title>   USB   </Title><Icon><On>/YamahaRemoteControl/Icons/icon011.png</On><Off></Off></Icon><Src_Name>iPod_USB</Src_Name><Src_Number>1</Src_Number></Item_7><Item_8><Param>TUNER</Param><RW>RW</RW><Title>  TUNER  </Title><Icon><On>/YamahaRemoteControl/Icons/icon008.png</On><Off></Off></Icon><Src_Name>Tuner</Src_Name><Src_Number>1</Src_Number></Item_8><Item_9><Param>HDMI1</Param><RW>RW</RW><Title>PS3      </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:PlayStation
+        3</Src_Name><Src_Number>1</Src_Number></Item_9><Item_10><Param>HDMI2</Param><RW>RW</RW><Title>  HDMI2  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:PlayStation
+        4</Src_Name><Src_Number>1</Src_Number></Item_10><Item_11><Param>HDMI3</Param><RW>RW</RW><Title>  HDMI3  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_11><Item_12><Param>HDMI4</Param><RW>RW</RW><Title>Chromecas</Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:Chromecast</Src_Name><Src_Number>1</Src_Number></Item_12><Item_13><Param>HDMI5</Param><RW>RW</RW><Title>  HDMI5  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_13><Item_14><Param>HDMI6</Param><RW>RW</RW><Title>  HDMI6  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_14><Item_15><Param>AV1</Param><RW>RW</RW><Title>   AV1   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_15><Item_16><Param>AV2</Param><RW>RW</RW><Title>   AV2   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_16><Item_17><Param>AV3</Param><RW>RW</RW><Title>   AV3   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_17><Item_18><Param>AV4</Param><RW>RW</RW><Title>   AV4   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_18><Item_19><Param>AV5</Param><RW>RW</RW><Title>   AV5   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_19><Item_20><Param>AV6</Param><RW>RW</RW><Title>   AV6   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_20><Item_21><Param>AUX</Param><RW>RW</RW><Title>   AUX   </Title><Icon><On>/YamahaRemoteControl/Icons/icon104.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_21></Input_Sel_Item></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '4236'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Input><Input_Sel></Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '101'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Input><Input_Sel>HDMI2</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Input><Input_Sel></Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '101'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI2</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_RX_V577/test_menu.yaml
+++ b/tests/integration/cassettes/test_RX_V577/test_menu.yaml
@@ -1,0 +1,584 @@
+interactions:
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel_Item>GetParam</Input_Sel_Item></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel_Item><Item_1><Param>Pandora</Param><RW>RW</RW><Title>
+        Pandora </Title><Icon><On>/YamahaRemoteControl/Icons/icon075.png</On><Off></Off></Icon><Src_Name>Pandora</Src_Name><Src_Number>1</Src_Number></Item_1><Item_2><Param>Spotify</Param><RW>RW</RW><Title>
+        Spotify </Title><Icon><On>/YamahaRemoteControl/Icons/icon102.png</On><Off></Off></Icon><Src_Name>Spotify</Src_Name><Src_Number>1</Src_Number></Item_2><Item_3><Param>AirPlay</Param><RW>RW</RW><Title>
+        AirPlay </Title><Icon><On>/YamahaRemoteControl/Icons/icon067.png</On><Off></Off></Icon><Src_Name>AirPlay</Src_Name><Src_Number>1</Src_Number></Item_3><Item_4><Param>SERVER</Param><RW>RW</RW><Title>
+        SERVER  </Title><Icon><On>/YamahaRemoteControl/Icons/icon006.png</On><Off></Off></Icon><Src_Name>SERVER</Src_Name><Src_Number>1</Src_Number></Item_4><Item_5><Param>NET
+        RADIO</Param><RW>RW</RW><Title>NET RADIO</Title><Icon><On>/YamahaRemoteControl/Icons/icon005.png</On><Off></Off></Icon><Src_Name>NET_RADIO</Src_Name><Src_Number>1</Src_Number></Item_5><Item_6><Param>USB</Param><RW>RW</RW><Title>   USB   </Title><Icon><On>/YamahaRemoteControl/Icons/icon009.png</On><Off></Off></Icon><Src_Name>USB</Src_Name><Src_Number>1</Src_Number></Item_6><Item_7><Param>iPod
+        (USB)</Param><RW>R</RW><Title>   USB   </Title><Icon><On>/YamahaRemoteControl/Icons/icon011.png</On><Off></Off></Icon><Src_Name>iPod_USB</Src_Name><Src_Number>1</Src_Number></Item_7><Item_8><Param>TUNER</Param><RW>RW</RW><Title>  TUNER  </Title><Icon><On>/YamahaRemoteControl/Icons/icon008.png</On><Off></Off></Icon><Src_Name>Tuner</Src_Name><Src_Number>1</Src_Number></Item_8><Item_9><Param>HDMI1</Param><RW>RW</RW><Title>PS3      </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:PlayStation
+        3</Src_Name><Src_Number>1</Src_Number></Item_9><Item_10><Param>HDMI2</Param><RW>RW</RW><Title>  HDMI2  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:PlayStation
+        4</Src_Name><Src_Number>1</Src_Number></Item_10><Item_11><Param>HDMI3</Param><RW>RW</RW><Title>  HDMI3  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_11><Item_12><Param>HDMI4</Param><RW>RW</RW><Title>Chromecas</Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name>Osdname:Chromecast</Src_Name><Src_Number>1</Src_Number></Item_12><Item_13><Param>HDMI5</Param><RW>RW</RW><Title>  HDMI5  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_13><Item_14><Param>HDMI6</Param><RW>RW</RW><Title>  HDMI6  </Title><Icon><On>/YamahaRemoteControl/Icons/icon004.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_14><Item_15><Param>AV1</Param><RW>RW</RW><Title>   AV1   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_15><Item_16><Param>AV2</Param><RW>RW</RW><Title>   AV2   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_16><Item_17><Param>AV3</Param><RW>RW</RW><Title>   AV3   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_17><Item_18><Param>AV4</Param><RW>RW</RW><Title>   AV4   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_18><Item_19><Param>AV5</Param><RW>RW</RW><Title>   AV5   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_19><Item_20><Param>AV6</Param><RW>RW</RW><Title>   AV6   </Title><Icon><On>/YamahaRemoteControl/Icons/icon003.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_20><Item_21><Param>AUX</Param><RW>RW</RW><Title>   AUX   </Title><Icon><On>/YamahaRemoteControl/Icons/icon104.png</On><Off></Off></Icon><Src_Name></Src_Name><Src_Number>1</Src_Number></Item_21></Input_Sel_Item></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '4236'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '103'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Input><Input_Sel></Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '101'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><NET_RADIO><List_Info>GetParam</List_Info></NET_RADIO></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '87'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><NET_RADIO><List_Info><Menu_Status>Ready</Menu_Status><Menu_Layer>1</Menu_Layer><Menu_Name>NET
+        RADIO</Menu_Name><Current_List><Line_1><Txt>Bookmarks</Txt><Attribute>Container</Attribute></Line_1><Line_2><Txt>Locations</Txt><Attribute>Container</Attribute></Line_2><Line_3><Txt>Genres</Txt><Attribute>Container</Attribute></Line_3><Line_4><Txt>New
+        Stations</Txt><Attribute>Container</Attribute></Line_4><Line_5><Txt>Popular
+        Stations</Txt><Attribute>Container</Attribute></Line_5><Line_6><Txt>Podcasts</Txt><Attribute>Container</Attribute></Line_6><Line_7><Txt>Help</Txt><Attribute>Container</Attribute></Line_7><Line_8><Txt>Get
+        Access Code</Txt><Attribute>Container</Attribute></Line_8></Current_List><Cursor_Position><Current_Line>1</Current_Line><Max_Line>8</Max_Line></Cursor_Position></List_Info></NET_RADIO></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '851'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><NET_RADIO><List_Control><Jump_Line>3</Jump_Line></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '109'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><NET_RADIO><List_Control><Jump_Line></Jump_Line></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '115'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><NET_RADIO><List_Control><Cursor>Up</Cursor></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><NET_RADIO><List_Control><Cursor></Cursor></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '109'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>NET RADIO</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><NET_RADIO><List_Control><Cursor>Down</Cursor></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><NET_RADIO><List_Control><Cursor></Cursor></List_Control></NET_RADIO></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '109'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Input><Input_Sel></Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '101'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Cursor_Control><Cursor>Right</Cursor></Cursor_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Cursor_Control><Cursor></Cursor></Cursor_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '113'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Input><Input_Sel>GetParam</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '102'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Input><Input_Sel>HDMI1</Input_Sel></Input></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '106'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Cursor_Control><Cursor>Left</Cursor></Cursor_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Cursor_Control><Cursor></Cursor></Cursor_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '113'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cassettes/test_RX_V577/test_on_off.yaml
+++ b/tests/integration/cassettes/test_RX_V577/test_on_off.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Power_Control><Power>GetParam</Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Power_Control><Power>Standby</Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '116'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="PUT"><Main_Zone><Power_Control><Power>On</Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="PUT" RC="0"><Main_Zone><Power_Control><Power></Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '109'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+- request:
+    body: <YAMAHA_AV cmd="GET"><Main_Zone><Power_Control><Power>GetParam</Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - text/xml
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: http://192.168.1.100/YamahaRemoteControl/ctrl
+  response:
+    body:
+      string: <YAMAHA_AV rsp="GET" RC="0"><Main_Zone><Power_Control><Power>On</Power></Power_Control></Main_Zone></YAMAHA_AV>
+    headers:
+      Content-Length:
+      - '111'
+      Content-Type:
+      - text/xml; charset="utf-8"
+      Server:
+      - AV_Receiver/3.1 (RX-V577)
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def vcr_config():
+    return {'match_on': ['method', 'path', 'raw_body']}
+
+
+@pytest.fixture(scope='module')
+def vcr_cassette_dir(request):
+    # Put all cassettes in tests/integration/cassettes/{module}/{test}.yaml
+    return os.path.join('tests/integration/cassettes', request.module.__name__)

--- a/tests/integration/test_RX_V577.py
+++ b/tests/integration/test_RX_V577.py
@@ -1,0 +1,58 @@
+"""Integration test for the RX-V577 model receiver."""
+import pytest
+
+import rxv
+
+
+@pytest.fixture
+def rx(vcr):
+    with vcr.use_cassette('RX-V577.yaml'):
+        return rxv.RXV(
+            'http://192.168.1.100:80/YamahaRemoteControl/ctrl', 'RX-V577'
+        )
+
+
+@pytest.mark.vcr()
+def test_on_off(rx):
+    assert rx.on is False, "reciver should be turned off"
+    rx.on = True
+    assert rx.on
+
+
+@pytest.mark.vcr()
+def test_basic_status(rx):
+    bs = rx.basic_status
+    assert bs.input == rx.input
+    assert bs.on == 'On'
+
+
+@pytest.mark.vcr()
+def test_inputs(rx):
+    assert rx.input in rx.inputs()
+    assert "HDMI1" in rx.inputs()
+    rx.input = "HDMI1"
+    assert rx.input == "HDMI1"
+    rx.input = "HDMI2"
+    assert rx.input == "HDMI2"
+
+
+@pytest.mark.vcr()
+def test_menu(rx):
+    rx.input = "NET RADIO"
+    assert rx.menu_status()
+    rx.menu_jump_line(3)
+    rx.menu_up()
+    rx.menu_down()
+
+    rx.input = "HDMI1"
+    rx.menu_right()
+    rx.menu_left()
+
+
+@pytest.mark.vcr()
+def test_fade(rx):
+    rx.volume = -50
+    rx.volume_fade(-48)
+    assert rx.volume == -48
+    rx.volume_fade(-51)
+    assert rx.volume == -51


### PR DESCRIPTION
Adding a testing dependency on `pytest-vcr` and an integration test for the RX-V577 model receiver.

I thought this might be useful for testing with actual devices. Feel free to reject this PR if it isn't something you'd like. It's basically a copy of `tests/check_integration.py` but with all the requests/responses from the RX-V577 model receiver stored in VCR cassette files.