### PR TITLE
Do not assume that assertions are enabled

### DIFF
--- a/rxv/rxv.py
+++ b/rxv/rxv.py
@@ -454,7 +454,7 @@ class RXV(object):
     @scene.setter
     def scene(self, scene_name):
         assert scene_name in self.scenes()
-        scene_number = self._scenes_cache.get(scene_name)
+        scene_number = self.scenes().get(scene_name)
         request_text = Scene.format(parameter=scene_number)
         self._request('PUT', request_text)
 


### PR DESCRIPTION
Trying to access `self._scenes_cache` only works after `self.scenes()`
has been invoked. Normally, the previous line of code (`assert
scene_name in self.scenes()`) would cause an invocation of
`self.scenes()` (and thereby populate `self._scenes_cache`), but that
doesn't actually happen if assertions are disabled!

Before this change
==================

    $ PYTHONOPTIMIZE=1 python -c 'import rxv; rxv.RXV("http://receiver/YamahaRemoteControl/ctrl").scene = "BD/DVD"; print("success!")'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/jeremy/src/github.com/wuub/rxv/rxv/rxv.py", line 457, in scene
        scene_number = self._scenes_cache.get(scene_name)
    AttributeError: 'NoneType' object has no attribute 'get'

After this change
=================

    $ PYTHONOPTIMIZE=1 python -c 'import rxv; rxv.RXV("http://receiver/YamahaRemoteControl/ctrl").scene = "BD/DVD"; print("success!")'
    success!